### PR TITLE
Benchmarking framework + CMA-ES handoff study

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -26,7 +26,7 @@ Python-Evo is an object-oriented framework designed for evolutionary optimizatio
 - **Factory Pattern Design**: Easy algorithm selection and instantiation
 - **Comprehensive Configuration**: Flexible parameter control with sensible defaults
 - **Rich Diagnostics**: Built-in logging for algorithm behavior analysis
-- **Boundary Handling**: Multiple constraint handling strategies
+- **Boundary Handling**: Multiple constraint handling strategies * ConstraintHandling
 - **Benchmark Functions**: Collection of standard test functions including CEC2017
 - **Visualization Tools**: Built-in plotting for convergence analysis
 

--- a/docs/covariance_handoff_when_it_matters.md
+++ b/docs/covariance_handoff_when_it_matters.md
@@ -1,0 +1,316 @@
+# When does CMA-ES → L-BFGS-B covariance handoff actually help?
+
+**TL;DR.** The CMA-ES covariance helps L-BFGS-B if and only if the basin
+it lands in is *anisotropic* and the warmup was long enough to learn
+that anisotropy. On near-isotropic multimodal problems (Rastrigin,
+Griewank) the C⁻¹ handoff is indistinguishable from a plain
+identity-Hessian handoff — basin selection determines the final
+fitness, not the choice of B₀. On highly anisotropic and rotated
+problems with sufficient warmup the C⁻¹ handoff wins by 3–4 orders of
+magnitude. With too-long warmup the C⁻¹ handoff can actually hurt
+because CMA-ES collapses its scale and feeds L-BFGS-B an ill-scaled
+initial Hessian.
+
+## Setup
+
+All experiments use the new `src/benchmarking/` framework: same seed →
+same `x0`, same CMA-ES RNG path. L-BFGS-B uses the Armijo line search
+(`More-Thuente` rejects multimodal ripples within ~20 evals).
+Default 15 seeds, total budget 10 000 evaluations, L-BFGS-B memory
+m = 5 unless noted. All plots come from re-running on this branch.
+
+Algorithms compared:
+
+- **CMA-ES** — standalone, full budget.
+- **L-BFGS-B** — standalone, full budget.
+- **Handoff (C⁻¹)** — CMA-ES warmup then L-BFGS-B with
+  B₀ = C⁻¹ (computed from CMA-ES's cached eigendecomposition).
+- **Handoff (identity)** — CMA-ES warmup then L-BFGS-B with the
+  default B₀ = I. Same warmup path as C⁻¹, so this isolates the value
+  of *passing the covariance* from the value of *starting from the
+  CMA-ES mean*.
+
+## Background — why I started this study
+
+The first batch on unrotated Rastrigin and Griewank produced this
+surprising result:
+
+| Problem   | C⁻¹ median f | Identity median f | C⁻¹ median evals | Identity median evals |
+|-----------|--------------|-------------------|------------------|-----------------------|
+| Rastrigin | 1.09e+01     | 1.09e+01          | 1567             | 1538                  |
+| Griewank  | 7.40e-03     | 7.40e-03          | 1569             | 1538                  |
+
+Identical to machine precision. The covariance was apparently useless.
+This was suspicious — the supervisor study on rotated Ellipsoid
+(`docs/supervisor_report_initial_hessian.md`) had shown a ~300× gap
+between identity and the true Hessian as B₀. Something about
+multimodal problems was different.
+
+## Hypothesis
+
+The local Hessian at the basin determines whether B₀ can help.
+
+- **Rastrigin** local Hessian at any minimum
+  is exactly `(2 + 40π²) · I` — perfectly isotropic. Verified
+  numerically:
+
+  ```
+  d=10: Rastrigin eigs [396.8, 396.8], cond=1
+  d=30: Rastrigin eigs [396.8, 396.8], cond=1
+  d=50: Rastrigin eigs [396.8, 396.8], cond=1
+  ```
+
+  No direction is privileged → identity is *already optimal* up to
+  scale, and L-BFGS-B's theta adapts the scale in one iteration.
+
+- **Griewank** local Hessian eigenvalues are
+  `1/2000 + 1/i`, giving condition number ≈ d.
+
+  ```
+  d=10: Griewank eigs [0.10, 1.0], cond=10
+  d=30: Griewank eigs [0.034, 1.0], cond=30
+  d=50: Griewank eigs [0.020, 1.0], cond=49
+  ```
+
+  Anisotropic, but axis-aligned. A few BFGS corrections can learn
+  the per-axis scaling from identity — the directional structure was
+  trivial.
+
+For covariance to *demonstrably* matter we need a problem where:
+
+1. The basin has condition number ≫ d, so identity is meaningfully
+   wrong.
+2. The anisotropy is **rotated** (not axis-aligned), so a few BFGS
+   corrections can't reconstruct it from identity alone.
+3. CMA-ES has had enough warmup to learn the rotation.
+
+## Tools added for the study
+
+- **`RotatedFunction`** (`src/utils/benchmark_functions.py`) — generic
+  wrapper that turns any `BenchmarkFunction` with a gradient into a
+  rotated variant. Inherits bounds, gradient transforms as
+  `Rᵀ · ∇f_base(R x)`, supports `"uniform_45" / "golden" / "random" /
+  explicit matrix` rotations.
+
+- **`RippledEllipsoid`** (same file) — `f(x) = Σ scale_i x_i² +
+  amplitude·Σ(1 − cos 2π x_i)`. Anisotropic quadratic + Rastrigin-style
+  ripples. Knobs:
+  - `condition` controls the eigenvalue spread of the quadratic part.
+  - `amplitude` controls multimodality. Large amplitude → many local
+    minima (Rastrigin-like). Small amplitude → near-unimodal,
+    dominated by the quadratic.
+
+- **`CMAESLBFGSBHandoff(transform="identity")`** — third handoff
+  baseline, alongside `"inverse"` and `"sigma_inverse"`. Lets us
+  isolate "share x₀" from "share covariance".
+
+- New example scripts:
+  - `examples/rotated_multimodal_handoff.py` — drives rotated
+    Rastrigin / Griewank sweeps.
+  - `examples/rippled_ellipsoid_handoff.py` — drives RippledEllipsoid
+    sweeps over (dimension × condition × memory × amplitude).
+  - `examples/rippled_handoff_timing_sweep.py` — sweeps warmup budget
+    on a fixed problem.
+
+## Experiment 1 — rotated Rastrigin and Griewank
+
+Rotating the multimodal functions doesn't introduce anisotropy where
+none exists. As predicted, the C⁻¹ vs identity gap stays absent.
+
+10D and 30D rotated Griewank, default m = 10, warmup 2500 evals:
+
+![rotated griewank m=10](../plots/hybrid/exp1_rotated_griewank_m10/convergence.png)
+
+| Problem        | C⁻¹ median f | Identity median f |
+|----------------|--------------|-------------------|
+| Griewank 10D   | 7.40e-03     | 7.40e-03          |
+| Griewank 30D   | 0.00e+00     | 0.00e+00          |
+
+The 30D case is degenerate — in high dimension `∏ cos(x_i/√i)` decays
+exponentially toward zero, so Griewank effectively becomes a sphere
+and even standalone L-BFGS-B reaches zero in ~70 evaluations from a
+random starting point.
+
+## Experiment 2 — rotated RippledEllipsoid, multimodal regime (amp=10)
+
+Strong ripples, moderate-to-high condition. The function has many
+local minima.
+
+10D + 30D, condition 1000, amplitude 10 (Rastrigin-strength ripples),
+m=5, warmup 2500:
+
+![rippled multimodal cond=1000](../plots/hybrid/exp3_rippled_c1000_m5/convergence.png)
+
+| Problem              | C⁻¹ median f | Identity median f |
+|----------------------|--------------|-------------------|
+| Rippled c=1000 d=10  | 3.15e+01     | 3.15e+01          |
+| Rippled c=1000 d=30  | 1.07e+02     | 1.07e+02          |
+
+**Identical.** Multimodality dominates: both algorithms find the same
+local minimum from the same CMA-ES mean. Their first descent steps
+differ (steepest descent vs Newton-like) but the basin floor is the
+same point and both reach it well within budget.
+
+Pushed harder (condition 10⁶, amplitude still 10, m=3):
+
+![rippled multimodal cond=1e6](../plots/hybrid/exp4_rippled_c1e6_m3/convergence.png)
+
+| Problem               | C⁻¹ median f | Identity median f |
+|-----------------------|--------------|-------------------|
+| Rippled c=1e6 d=10    | 2.79e+01     | 2.79e+01          |
+| Rippled c=1e6 d=30    | 1.78e+02     | 1.51e+02          |
+
+Now the descent paths actually diverge — they land in different local
+minima — but the *medians* are within noise of each other, and
+identity happens to win on 30D. With strong multimodality, B₀ steers
+into a slightly different basin; which basin is lower is essentially
+luck.
+
+**Takeaway:** the multimodal premise of the original task makes this
+particular question hard to answer in the multimodal regime itself.
+The handoff buys speed-to-basin-floor; it doesn't buy escape from
+multimodality.
+
+## Experiment 3 — rotated RippledEllipsoid, near-unimodal regime (amp=0.1)
+
+Drop the ripple amplitude until the cos-saddle curvature
+(`4π²·amplitude`) is small compared to the quadratic eigenvalues.
+The function is technically still multimodal in the low-scale
+dimensions, but the global basin is enormous and contains the entire
+trajectory once CMA-ES has had a few generations.
+
+condition = 10⁶, amplitude = 0.1, m = 5, warmup 2500:
+
+![rippled near-unimodal](../plots/hybrid/exp6_low_ripple_high_cond/convergence.png)
+
+| Problem      | CMA-ES    | L-BFGS-B   | C⁻¹ handoff | Identity handoff | C⁻¹ / identity |
+|--------------|-----------|------------|-------------|------------------|----------------|
+| d=10         | 3.90e-16  | 1.97e-15   | 4.82e-20    | 1.70e-15         | 35 000×        |
+| d=30         | 1.84e+02  | 8.22e-16   | 5.82e-18    | 3.79e-15         | 650×           |
+| d=50         | 4.56e+03  | 6.48e-16   | 8.54e-16    | 1.10e-14         | 13×            |
+
+This is the finding the supervisor study predicted: with rotated
+high-condition anisotropy, the CMA-ES covariance is genuinely
+informative and the C⁻¹ handoff descends to a much smaller absolute
+fitness than the identity handoff within the same total budget. The
+effect is strongest in 10D — both methods are deep into machine-zero
+territory, but C⁻¹'s Newton-like steps keep pushing while identity's
+steepest-descent steps plateau.
+
+L-BFGS-B alone is competitive here because the function is nearly
+unimodal — the ripples don't trap it.
+
+## Experiment 4 — warmup timing sweep
+
+How much CMA-ES warmup is needed before the covariance is worth
+trusting? And is there a point at which more warmup hurts?
+
+Fixed problem (rotated RippledEllipsoid, cond=10⁶, amp=0.1, d=30,
+m=5), fixed total budget 10 000. Warmup swept across {500, 1 500,
+3 000, 5 000, 7 500} evaluations; remainder goes to L-BFGS-B. Both
+C⁻¹ and identity transforms shown at each warmup.
+
+![warmup timing sweep](../plots/hybrid/exp7_timing_sweep/convergence.png)
+
+| Warmup (evals) | C⁻¹ median f | Identity median f | Winner |
+|----------------|--------------|-------------------|--------|
+| 500            | 5.46e-16     | 9.57e-16          | C⁻¹ (mild) |
+| 1 500          | 3.82e-16     | 1.72e-15          | C⁻¹ |
+| 3 000          | **1.88e-17** | 6.06e-15          | C⁻¹ |
+| 5 000          | 6.99e-05     | 1.33e-10          | identity |
+| 7 500          | 5.14e-02     | 1.15e-03          | identity |
+
+Two effects fight each other as warmup grows.
+
+1. **Information.** More warmup → CMA-ES has learned the rotation
+   more accurately → C⁻¹ is more informative.
+2. **Scale collapse.** As CMA-ES converges, the sqrt-eigenvalues `D`
+   shrink. C⁻¹ has eigenvalues `1/D²`, which blow up. Because the
+   framework's L-BFGS-B keeps `persist_initial_hessian=True`, this
+   ill-scaled B₀ stays in effect for the entire L-BFGS-B segment and
+   causes the optimizer to overshoot or stall on the now-tiny basin.
+
+The sweet spot is around warmup = 3 000 (≈ 100 CMA-ES generations on
+d=30). Beyond that, **passing the covariance is actively harmful** —
+the identity baseline reaches 1.3e-10 while the C⁻¹ run only gets to
+7.0e-05 (a 5×10⁵ swing in the opposite direction).
+
+Identity handoff also degrades with longer warmup, but for a different
+reason: less remaining L-BFGS-B budget. It declines monotonically.
+
+## Conclusions
+
+1. **On near-isotropic multimodal problems** (Rastrigin, Griewank in
+   their natural form), C⁻¹ and identity are indistinguishable. This
+   is not a bug; it reflects the geometry. The previous finding that
+   the handoff matches CMA-ES quality in <½ the evaluations stands —
+   the speed-up comes from sharing the warmup `x₀`, not the
+   covariance.
+
+2. **On rotated, ill-conditioned, near-unimodal problems**, the C⁻¹
+   handoff reaches a fitness 10¹–10⁴ times smaller than the identity
+   handoff in the same budget. This is the regime where the supervisor
+   ellipsoid result actually applies.
+
+3. **The covariance handoff is not always safe to apply**: long
+   warmup collapses the CMA-ES scale, and `1 / D²` becomes
+   numerically large. Combined with `persist_initial_hessian=True`,
+   this poisons the entire L-BFGS-B run. A trace-normalized variant
+   (`C / trace(C) · n`, then inverted) or a fix that drops
+   `persist_initial_hessian` after a few iterations might be worth
+   exploring.
+
+4. **For the thesis benchmarking story**, the honest claim is:
+   - On multimodal problems whose local Hessian is near-isotropic
+     (Rastrigin), the handoff just buys speed (shared `x₀`).
+   - On problems whose local Hessian is anisotropic and rotated
+     (RippledEllipsoid, the original supervisor Ellipsoid study),
+     the covariance is the dominant value of the handoff.
+   - There is a non-trivial timing tradeoff: too short and the
+     covariance is noisy; too long and the scale collapses.
+
+## Reproducing
+
+```bash
+# Multimodal baseline (the puzzling one)
+PYTHONPATH=. pdm run python examples/multimodal_handoff_benchmark.py \
+    --include-identity-baseline --num-workers 6 \
+    --output-dir plots/hybrid/multimodal_handoff
+
+# Rotated multimodal (no anisotropy gained)
+PYTHONPATH=. pdm run python examples/rotated_multimodal_handoff.py \
+    --bases Griewank --dimensions 10 30 --memory 10 \
+    --num-workers 6 --output-dir plots/hybrid/exp1_rotated_griewank_m10
+
+# Rotated rippled multimodal (still no clear winner)
+PYTHONPATH=. pdm run python examples/rippled_ellipsoid_handoff.py \
+    --dimensions 10 30 --conditions 1000 --memory 5 \
+    --num-workers 6 --output-dir plots/hybrid/exp3_rippled_c1000_m5
+
+# Rotated rippled near-unimodal (C^-1 wins by orders of magnitude)
+PYTHONPATH=. pdm run python examples/rippled_ellipsoid_handoff.py \
+    --dimensions 10 30 50 --conditions 1000000 --memory 5 \
+    --amplitude 0.1 --num-workers 6 \
+    --output-dir plots/hybrid/exp6_low_ripple_high_cond
+
+# Warmup timing sweep on the regime where C^-1 wins
+PYTHONPATH=. pdm run python examples/rippled_handoff_timing_sweep.py \
+    --dimensions 30 --warmup-budgets 500 1500 3000 5000 7500 \
+    --num-workers 6 --output-dir plots/hybrid/exp7_timing_sweep
+```
+
+## Open questions
+
+- Is the scale-collapse failure mode at long warmup an argument for
+  the `sigma_inverse` transform (which divides C⁻¹ by σ², partially
+  cancelling the collapse)? Worth running the sweep with all three
+  transforms side by side.
+- Would dropping `persist_initial_hessian=True` after the first few
+  iterations recover the long-warmup case? The persist flag was the
+  right default for the original rotated-ellipsoid study; it might
+  not be for handoff scenarios where B₀ comes from a converged
+  distribution.
+- On problems whose anisotropy isn't aligned to either coordinate
+  axes or the principal eigenvectors CMA-ES finds, does C⁻¹ still
+  help, or does the "wrong rotation" hurt? Rotation-mode ablation
+  would settle this.

--- a/examples/cmaes_handoff_study.py
+++ b/examples/cmaes_handoff_study.py
@@ -24,20 +24,33 @@ plt.ioff()
 plt.switch_backend("Agg")
 
 
-def build_transformations(covariance_matrix, sigma, dimensions):
-    """Build different Hessian matrices from the CMA-ES covariance."""
-    regularized = covariance_matrix + 1e-10 * np.eye(dimensions)
+def build_transformations(eigenvectors, eigenvalues_sqrt, sigma, dimensions):
+    """Build different Hessian matrices from the CMA-ES eigendecomposition.
 
-    normalized = covariance_matrix / np.trace(covariance_matrix) * dimensions
-    normalized_regularized = normalized + 1e-10 * np.eye(dimensions)
+    Reuses the eigenvectors B and the sqrt-eigenvalues D that CMA-ES already
+    keeps internally (C = B diag(D^2) B^T). Building C and its inverse from
+    them avoids an extra ``np.linalg.inv`` call on the outside.
+    """
+    eigenvalues = np.maximum(eigenvalues_sqrt**2, 1e-30)
+    inv_eigenvalues = 1.0 / eigenvalues
+
+    covariance_matrix = (eigenvectors * eigenvalues) @ eigenvectors.T
+    covariance_inverse = (eigenvectors * inv_eigenvalues) @ eigenvectors.T
+
+    trace_C = float(np.sum(eigenvalues))
+    normalization_factor = dimensions / trace_C
+    normalized_covariance = covariance_matrix * normalization_factor
+    normalized_inverse = covariance_inverse / normalization_factor
+
+    sigma_sq_inverse = covariance_inverse / (sigma * sigma)
 
     return {
         "Identity (no CMA-ES info)": None,
         "Raw covariance C": covariance_matrix,
-        "Inverse C^{-1}": np.linalg.inv(regularized),
-        "Inverse scaled (s^2 C)^{-1}": np.linalg.inv(sigma**2 * regularized),
-        "Normalized C / tr(C) * n": normalized,
-        "Inv. normalized (C/tr*n)^{-1}": np.linalg.inv(normalized_regularized),
+        "Inverse C^{-1}": covariance_inverse,
+        "Inverse scaled (s^2 C)^{-1}": sigma_sq_inverse,
+        "Normalized C / tr(C) * n": normalized_covariance,
+        "Inv. normalized (C/tr*n)^{-1}": normalized_inverse,
     }
 
 
@@ -112,11 +125,11 @@ def run_handoff_study(
         )
         result_cmaes = optimizer_cmaes.optimize()
 
-        # Extract CMA-ES state from the logs and public API
-        logs = result_cmaes.diagnostic
-        covariance_matrix = logs.covariance_matrix[-1]
-        sigma = logs.sigma[-1]
-        starting_point = logs.mean_vector[-1]
+        # Extract CMA-ES state directly from the cached eigendecomposition.
+        # CMA-ES already maintains B, D; reusing them avoids an outside inv().
+        eigenvectors, eigenvalues_sqrt = optimizer_cmaes.get_eigendecomposition()
+        sigma = optimizer_cmaes.sigma
+        starting_point = optimizer_cmaes.mean
         warmup_evals = result_cmaes.evaluations
 
         print(f"CMA-ES warm-up: {warmup_evals} evals, "
@@ -126,7 +139,7 @@ def run_handoff_study(
         # Phase 2: L-BFGS-B with each transformation
         lbfgsb_budget = 5000
         transformations = build_transformations(
-            covariance_matrix, sigma, dimensions
+            eigenvectors, eigenvalues_sqrt, sigma, dimensions
         )
 
         cmaes_iters = len(result_cmaes.diagnostic.iteration)

--- a/examples/handoff_timing_sweep.py
+++ b/examples/handoff_timing_sweep.py
@@ -1,0 +1,284 @@
+"""Handoff timing sweep on multimodal problems.
+
+Same comparison as ``multimodal_handoff_benchmark.py`` but with a family
+of handoff timings instead of a single one. Five handoffs are run alongside
+CMA-ES standalone and L-BFGS-B standalone, all under the same total budget.
+
+Because every run shares the same x0 (deterministic from the seed) AND
+the same CMA-ES RNG, all handoff curves trace the *same* CMA-ES path
+until their handoff point — the median plot shows them forking off one
+by one as their respective L-BFGS-B refinement kicks in.
+
+Reads as: "would handing off here have been better?".
+
+Timing can be expressed in *evaluations* (default) or *iterations* (CMA-ES
+generations) via ``--timing-unit``. Iterations are converted to evaluations
+using the CMA-ES population size: evals = generations * (pop_size + 1).
+"""
+
+import argparse
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+
+from src.algorithms.choices import AlgorithmChoice
+from src.algorithms.cmaes.config import CMAESConfig
+from src.algorithms.lbfgsb.config import LBFGSBConfig, LineSearchMethod
+from src.benchmarking import (
+    Benchmark,
+    BenchmarkPlotter,
+    CMAESLBFGSBHandoff,
+    Problem,
+    SingleAlgorithm,
+)
+from src.utils.benchmark_functions import Griewank, Rastrigin
+
+
+plt.ioff()
+plt.switch_backend("Agg")
+
+
+# Sequential green palette for handoff timings — earliest handoff is the
+# lightest, latest is the darkest. CMA-ES and L-BFGS-B keep their
+# distinctive colours so they stand out as references.
+HANDOFF_PALETTE = [
+    "#a8e6c9",  # earliest
+    "#74c69d",
+    "#40916c",
+    "#2d6a4f",
+    "#1b4332",  # latest
+]
+
+REFERENCE_COLORS = {
+    "CMA-ES":   "#e74c3c",
+    "L-BFGS-B": "#3498db",
+}
+
+
+def cmaes_evals_per_generation(dimensions: int) -> int:
+    """CMA-ES costs pop_size + 1 evaluations per generation (the +1 is the
+    mean evaluation logged each iteration). pop_size derives from the
+    default CMAESConfig given the problem dimension."""
+    return CMAESConfig(dimensions=dimensions).population_size + 1
+
+
+def resolve_warmup_budgets(
+    timings: list[int],
+    timing_unit: str,
+    dimensions: int,
+) -> list[tuple[int, str]]:
+    """Translate user-facing timings into (warmup_evals, label).
+
+    label is what shows up on plot legends — keeps the user's chosen unit
+    visible.
+    """
+    if timing_unit == "evaluations":
+        return [(t, f"@ {t} evals") for t in timings]
+    if timing_unit == "iterations":
+        evals_per_gen = cmaes_evals_per_generation(dimensions)
+        return [
+            (t * evals_per_gen, f"@ {t} gen ({t * evals_per_gen} evals)")
+            for t in timings
+        ]
+    raise ValueError(
+        f"Unknown timing-unit {timing_unit!r}; use 'evaluations' or 'iterations'."
+    )
+
+
+def build_algorithms(
+    total_budget: int,
+    warmup_pairs: list[tuple[int, str]],
+    initial_sigma: float,
+    memory_size: int,
+):
+    """One CMA-ES standalone + one L-BFGS-B standalone + one handoff per timing.
+
+    Each handoff splits the total budget so its (CMA-ES warmup) +
+    (L-BFGS-B post-handoff) budgets sum to ``total_budget``.
+    """
+    cmaes_only = SingleAlgorithm(
+        name="CMA-ES",
+        color=REFERENCE_COLORS["CMA-ES"],
+        algorithm=AlgorithmChoice.CMAES,
+        config_factory=lambda d: CMAESConfig(
+            dimensions=d, budget=total_budget, sigma=initial_sigma,
+        ),
+    )
+
+    lbfgsb_only = SingleAlgorithm(
+        name="L-BFGS-B",
+        color=REFERENCE_COLORS["L-BFGS-B"],
+        algorithm=AlgorithmChoice.LBFGSB,
+        config_factory=lambda d: LBFGSBConfig(
+            dimensions=d, budget=total_budget, m=memory_size,
+            pgtol=1e-10, factr=0,
+            line_search=LineSearchMethod.ARMIJO,
+        ),
+    )
+
+    handoffs: list[CMAESLBFGSBHandoff] = []
+    for idx, (warmup_budget, label_suffix) in enumerate(warmup_pairs):
+        post_handoff_budget = total_budget - warmup_budget
+        color = HANDOFF_PALETTE[idx % len(HANDOFF_PALETTE)]
+        handoffs.append(
+            CMAESLBFGSBHandoff(
+                name=f"Handoff {label_suffix}",
+                color=color,
+                cmaes_config_factory=lambda d, b=warmup_budget: CMAESConfig(
+                    dimensions=d, budget=b, sigma=initial_sigma,
+                ),
+                lbfgsb_config_factory=lambda d, b=post_handoff_budget: LBFGSBConfig(
+                    dimensions=d, budget=b, m=memory_size,
+                    pgtol=1e-10, factr=0,
+                    line_search=LineSearchMethod.ARMIJO,
+                ),
+                transform="inverse",
+            )
+        )
+
+    return [cmaes_only, lbfgsb_only, *handoffs]
+
+
+def run_handoff_timing_sweep(
+    dimensions: int,
+    total_budget: int,
+    timings: list[int],
+    timing_unit: str,
+    num_seeds: int,
+    initial_sigma_rastrigin: float,
+    initial_sigma_griewank: float,
+    memory_size: int,
+    num_workers: int,
+    output_dir: Path,
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    seeds = list(range(num_seeds))
+
+    warmup_pairs = resolve_warmup_budgets(timings, timing_unit, dimensions)
+    print(f"Timing unit: {timing_unit}")
+    for raw, (evals, label) in zip(timings, warmup_pairs):
+        print(f"  {raw} {timing_unit} -> {evals} evals  (label: 'Handoff {label}')")
+
+    sub_settings = [
+        ("Rastrigin", Rastrigin(dimensions), initial_sigma_rastrigin),
+        ("Griewank",  Griewank(dimensions),  initial_sigma_griewank),
+    ]
+
+    all_problems: list[Problem] = []
+    combined_traces: dict = {}
+
+    # One representative algorithm list (Griewank's sigma) for the plotter;
+    # algorithm metadata (name, color) is the same across sigmas so this is
+    # safe to use for plotting both panels.
+    representative_algorithms = build_algorithms(
+        total_budget, warmup_pairs, initial_sigma_griewank, memory_size,
+    )
+
+    for problem_name, function, initial_sigma in sub_settings:
+        problem = Problem.from_benchmark(problem_name, function)
+        algorithms = build_algorithms(
+            total_budget, warmup_pairs, initial_sigma, memory_size,
+        )
+
+        bench = Benchmark(
+            problems=[problem],
+            algorithms=algorithms,
+            seeds=seeds,
+            output_dir=output_dir / problem_name.lower(),
+            num_workers=num_workers,
+        )
+        bench.run(verbose=True)
+        bench.print_summary()
+
+        all_problems.append(problem)
+        for key, traces in bench.traces.items():
+            combined_traces[key] = traces
+
+    plotter = BenchmarkPlotter(
+        problems=all_problems,
+        algorithms=representative_algorithms,
+        traces=combined_traces,
+        output_dir=output_dir,
+    )
+
+    # IQR bands turned off — with 7 algorithms in one panel they would
+    # smother the median lines.
+    plotter.plot_convergence_grid(
+        save_path=output_dir / "handoff_timing_convergence.png",
+        title=(
+            f"Handoff timing sweep: when to switch from CMA-ES to L-BFGS-B "
+            f"({dimensions}D, {num_seeds} seeds, total budget {total_budget})"
+        ),
+        show_iqr=False,
+    )
+
+    print(f"\nPlot saved to: {(output_dir / 'handoff_timing_convergence.png').absolute()}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dimensions", type=int, default=10)
+    parser.add_argument("--total-budget", type=int, default=10000)
+    parser.add_argument(
+        "--timing-unit", choices=("evaluations", "iterations"), default="evaluations",
+        help=(
+            "Whether --handoff-timings is given in CMA-ES function evaluations "
+            "or CMA-ES generations/iterations. Iterations are converted via "
+            "evals = iters * (pop_size + 1) using the default CMA-ES pop_size."
+        ),
+    )
+    parser.add_argument(
+        "--handoff-timings", type=int, nargs="+", default=None,
+        help=(
+            "Warmup timings to sweep over. Interpreted in the unit given by "
+            "--timing-unit. Defaults: [250, 500, 1000, 1500, 2500] evaluations "
+            "or [20, 50, 100, 150, 250] iterations."
+        ),
+    )
+    parser.add_argument("--num-seeds", type=int, default=25)
+    parser.add_argument("--memory-size", type=int, default=10)
+    parser.add_argument("--sigma-rastrigin", type=float, default=2.0)
+    parser.add_argument("--sigma-griewank", type=float, default=200.0)
+    parser.add_argument(
+        "--num-workers", type=int, default=1,
+        help="Process count for parallel run execution (>1 uses joblib loky backend).",
+    )
+    parser.add_argument(
+        "--output-dir", type=Path,
+        default=Path("plots/hybrid/handoff_timing_sweep"),
+    )
+    args = parser.parse_args()
+
+    if args.handoff_timings is None:
+        args.handoff_timings = (
+            [250, 500, 1000, 1500, 2500]
+            if args.timing_unit == "evaluations"
+            else [20, 50, 100, 150, 250]
+        )
+
+    # Validate: every timing must convert to a budget strictly less than total.
+    evals_per_gen = cmaes_evals_per_generation(args.dimensions)
+    for raw in args.handoff_timings:
+        evals = raw if args.timing_unit == "evaluations" else raw * evals_per_gen
+        if evals >= args.total_budget:
+            raise ValueError(
+                f"Timing {raw} {args.timing_unit} -> {evals} evals exceeds "
+                f"total-budget {args.total_budget}."
+            )
+
+    run_handoff_timing_sweep(
+        dimensions=args.dimensions,
+        total_budget=args.total_budget,
+        timings=sorted(args.handoff_timings),
+        timing_unit=args.timing_unit,
+        num_seeds=args.num_seeds,
+        initial_sigma_rastrigin=args.sigma_rastrigin,
+        initial_sigma_griewank=args.sigma_griewank,
+        memory_size=args.memory_size,
+        num_workers=args.num_workers,
+        output_dir=args.output_dir,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/multimodal_handoff_benchmark.py
+++ b/examples/multimodal_handoff_benchmark.py
@@ -1,0 +1,276 @@
+"""Multimodal handoff benchmark: CMA-ES + L-BFGS-B vs each alone.
+
+Compares four algorithms on Rastrigin and Griewank by default:
+
+1. CMA-ES standalone, full budget.
+2. L-BFGS-B standalone, full budget.
+3. CMA-ES warm-up -> L-BFGS-B with C^{-1} initial Hessian (the headline
+   handoff).
+4. CMA-ES warm-up -> L-BFGS-B with identity B_0 (same x0 as the handoff
+   but no covariance information passed; isolates "does the covariance
+   actually help" from "does the CMA-ES warmup find a better basin").
+
+Same seed produces the same starting point for all algorithms, and the
+same CMA-ES RNG path, so the convergence curves of (1), (3), and (4)
+match each other up to their respective handoff points.
+
+The total evaluation budget is fixed across all algorithms, so the
+comparison is fair on the dimension the user cares about most: function
+evaluations.
+"""
+
+import argparse
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+
+from src.algorithms.choices import AlgorithmChoice
+from src.algorithms.cmaes.config import CMAESConfig
+from src.algorithms.lbfgsb.config import LBFGSBConfig, LineSearchMethod
+from src.benchmarking import (
+    Benchmark,
+    BenchmarkPlotter,
+    CMAESLBFGSBHandoff,
+    Problem,
+    SingleAlgorithm,
+)
+from src.utils.benchmark_functions import Griewank, Rastrigin
+
+
+plt.ioff()
+plt.switch_backend("Agg")
+
+
+COLORS = {
+    "CMA-ES":                          "#e74c3c",
+    "L-BFGS-B":                        "#3498db",
+    "CMA-ES -> L-BFGS-B (C^-1)":       "#2ecc71",
+    "CMA-ES -> L-BFGS-B (identity)":   "#9b59b6",
+}
+
+
+def build_algorithms(
+    total_budget: int,
+    cmaes_warmup_budget: int,
+    initial_sigma: float,
+    memory_size: int,
+    include_identity_baseline: bool,
+):
+    """Algorithms sharing one total evaluation budget.
+
+    Handoffs split the budget: ``cmaes_warmup_budget`` evaluations on
+    CMA-ES, the rest on L-BFGS-B.
+    """
+    lbfgsb_handoff_budget = total_budget - cmaes_warmup_budget
+
+    cmaes_only = SingleAlgorithm(
+        name="CMA-ES",
+        color=COLORS["CMA-ES"],
+        algorithm=AlgorithmChoice.CMAES,
+        config_factory=lambda d: CMAESConfig(
+            dimensions=d,
+            budget=total_budget,
+            sigma=initial_sigma,
+        ),
+    )
+
+    # ARMIJO (simple backtracking) handles the cosine ripples of multimodal
+    # functions much better than More-Thuente: the strong-Wolfe curvature
+    # condition rejects valid descent steps when the gradient wiggles, so
+    # More-Thuente bails out within ~20 evals near the basin floor while
+    # Armijo descends steadily. factr=0 disables function-value tolerance.
+    lbfgsb_only = SingleAlgorithm(
+        name="L-BFGS-B",
+        color=COLORS["L-BFGS-B"],
+        algorithm=AlgorithmChoice.LBFGSB,
+        config_factory=lambda d: LBFGSBConfig(
+            dimensions=d,
+            budget=total_budget,
+            m=memory_size,
+            pgtol=1e-10,
+            factr=0,
+            line_search=LineSearchMethod.ARMIJO,
+        ),
+    )
+
+    handoff_inverse = CMAESLBFGSBHandoff(
+        name="CMA-ES -> L-BFGS-B (C^-1)",
+        color=COLORS["CMA-ES -> L-BFGS-B (C^-1)"],
+        cmaes_config_factory=lambda d: CMAESConfig(
+            dimensions=d,
+            budget=cmaes_warmup_budget,
+            sigma=initial_sigma,
+        ),
+        lbfgsb_config_factory=lambda d: LBFGSBConfig(
+            dimensions=d,
+            budget=lbfgsb_handoff_budget,
+            m=memory_size,
+            pgtol=1e-10,
+            factr=0,
+            line_search=LineSearchMethod.ARMIJO,
+        ),
+        transform="inverse",
+    )
+
+    algorithms = [cmaes_only, lbfgsb_only, handoff_inverse]
+
+    if include_identity_baseline:
+        handoff_identity = CMAESLBFGSBHandoff(
+            name="CMA-ES -> L-BFGS-B (identity)",
+            color=COLORS["CMA-ES -> L-BFGS-B (identity)"],
+            cmaes_config_factory=lambda d: CMAESConfig(
+                dimensions=d,
+                budget=cmaes_warmup_budget,
+                sigma=initial_sigma,
+            ),
+            lbfgsb_config_factory=lambda d: LBFGSBConfig(
+                dimensions=d,
+                budget=lbfgsb_handoff_budget,
+                m=memory_size,
+                pgtol=1e-10,
+                factr=0,
+                line_search=LineSearchMethod.ARMIJO,
+            ),
+            transform="identity",
+        )
+        algorithms.append(handoff_identity)
+
+    return algorithms
+
+
+def run_multimodal_handoff(
+    dimensions: int,
+    total_budget: int,
+    cmaes_warmup_budget: int,
+    num_seeds: int,
+    initial_sigma_rastrigin: float,
+    initial_sigma_griewank: float,
+    memory_size: int,
+    num_workers: int,
+    include_identity_baseline: bool,
+    output_dir: Path,
+) -> None:
+    """Two separate sub-benchmarks (one per problem) so each can use its own
+    initial sigma; otherwise the framework would force a single sigma across
+    both Rastrigin (small box [-5.12, 5.12]) and Griewank (big box [-600, 600])."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    seeds = list(range(num_seeds))
+
+    sub_settings = [
+        ("Rastrigin", Rastrigin(dimensions), initial_sigma_rastrigin),
+        ("Griewank",  Griewank(dimensions),  initial_sigma_griewank),
+    ]
+
+    all_problems: list[Problem] = []
+    all_algorithms = build_algorithms(
+        total_budget, cmaes_warmup_budget, initial_sigma_rastrigin, memory_size,
+        include_identity_baseline,
+    )
+    combined_traces: dict = {}
+
+    for problem_name, function, initial_sigma in sub_settings:
+        problem = Problem.from_benchmark(problem_name, function)
+        algorithms = build_algorithms(
+            total_budget, cmaes_warmup_budget, initial_sigma, memory_size,
+            include_identity_baseline,
+        )
+
+        bench = Benchmark(
+            problems=[problem],
+            algorithms=algorithms,
+            seeds=seeds,
+            output_dir=output_dir / problem_name.lower(),
+            num_workers=num_workers,
+        )
+        bench.run(verbose=True)
+        bench.print_summary()
+
+        all_problems.append(problem)
+        for key, traces in bench.traces.items():
+            combined_traces[key] = traces
+
+    plotter = BenchmarkPlotter(
+        problems=all_problems,
+        algorithms=all_algorithms,
+        traces=combined_traces,
+        output_dir=output_dir,
+    )
+
+    plotter.plot_convergence_grid(
+        save_path=output_dir / "convergence.png",
+        title=(
+            f"Multimodal handoff: CMA-ES vs L-BFGS-B vs combined "
+            f"({dimensions}D, {num_seeds} seeds, total budget {total_budget})"
+        ),
+    )
+    plotter.plot_final_fitness_boxplot(
+        save_path=output_dir / "final_fitness.png",
+        title=(
+            f"Final fitness distribution ({dimensions}D, {num_seeds} seeds)"
+        ),
+    )
+
+    print(f"\nPlots saved to: {output_dir.absolute()}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dimensions", type=int, default=10)
+    parser.add_argument("--total-budget", type=int, default=10000)
+    parser.add_argument(
+        "--cmaes-warmup-budget", type=int, default=1500,
+        help=(
+            "Evaluations spent on CMA-ES warm-up before the handoff. "
+            "Too high and CMA-ES converges fully and L-BFGS-B has nothing "
+            "to refine; too low and CMA-ES hasn't found a basin yet."
+        ),
+    )
+    parser.add_argument("--num-seeds", type=int, default=25)
+    parser.add_argument("--memory-size", type=int, default=10)
+    parser.add_argument(
+        "--sigma-rastrigin", type=float, default=2.0,
+        help="Initial sigma for CMA-ES on Rastrigin (bounds [-5.12, 5.12]).",
+    )
+    parser.add_argument(
+        "--sigma-griewank", type=float, default=200.0,
+        help="Initial sigma for CMA-ES on Griewank (bounds [-600, 600]).",
+    )
+    parser.add_argument(
+        "--num-workers", type=int, default=1,
+        help="Process count for parallel run execution (>1 uses joblib loky backend).",
+    )
+    parser.add_argument(
+        "--include-identity-baseline", action="store_true",
+        help=(
+            "Add a 4th algorithm: CMA-ES warmup then L-BFGS-B with identity "
+            "B_0. Isolates the value of *passing covariance information* "
+            "from the value of *sharing a starting point*."
+        ),
+    )
+    parser.add_argument(
+        "--output-dir", type=Path,
+        default=Path("plots/hybrid/multimodal_handoff"),
+    )
+    args = parser.parse_args()
+
+    if args.cmaes_warmup_budget >= args.total_budget:
+        raise ValueError(
+            "cmaes-warmup-budget must be strictly less than total-budget"
+        )
+
+    run_multimodal_handoff(
+        dimensions=args.dimensions,
+        total_budget=args.total_budget,
+        cmaes_warmup_budget=args.cmaes_warmup_budget,
+        num_seeds=args.num_seeds,
+        initial_sigma_rastrigin=args.sigma_rastrigin,
+        initial_sigma_griewank=args.sigma_griewank,
+        memory_size=args.memory_size,
+        num_workers=args.num_workers,
+        include_identity_baseline=args.include_identity_baseline,
+        output_dir=args.output_dir,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/per_experiment_timing_sweep.py
+++ b/examples/per_experiment_timing_sweep.py
@@ -1,0 +1,296 @@
+"""Handoff timing sweep — one panel per experimental family.
+
+Builds the same problem under each named experimental family and runs a
+sweep of warmup budgets *expressed in CMA-ES generations* (translated
+to evaluations using the algorithm's default population size).
+
+Families supported (via ``--family``):
+- ``baseline``       — Rastrigin and Griewank, d=10, m=10. The original puzzle.
+- ``reproduce_old``  — Pure rotated Ellipsoid, d=50, m=5. Reproduces the old finding.
+- ``low_amp``        — Rotated RippledEllipsoid, amp=0.1, d=30, m=5. C^-1 wins dramatically.
+- ``multimodal``     — Rotated RippledEllipsoid, amp=1, d=50, m=5. Genuinely multimodal.
+
+Each family has its own sensible defaults but the script also takes
+overrides for total budget, warmup generations, num seeds, num workers,
+etc.
+"""
+
+import argparse
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+
+from src.algorithms.choices import AlgorithmChoice
+from src.algorithms.cmaes.config import CMAESConfig
+from src.algorithms.lbfgsb.config import LBFGSBConfig, LineSearchMethod
+from src.benchmarking import (
+    Benchmark,
+    BenchmarkPlotter,
+    CMAESLBFGSBHandoff,
+    Problem,
+    SingleAlgorithm,
+)
+from src.utils.benchmark_functions import (
+    Griewank,
+    Rastrigin,
+    RippledEllipsoid,
+    RotatedFunction,
+)
+
+
+plt.ioff()
+plt.switch_backend("Agg")
+
+
+PALETTE_INVERSE = ["#a8e6c9", "#74c69d", "#40916c", "#2d6a4f", "#1b4332"]
+PALETTE_IDENTITY = ["#e9d8fd", "#c5a3f5", "#9b59b6", "#7e3aa6", "#5b2785"]
+
+REFERENCE_COLORS = {
+    "CMA-ES":   "#e74c3c",
+    "L-BFGS-B": "#3498db",
+}
+
+
+def cmaes_evals_per_generation(dimensions: int) -> int:
+    """CMA-ES costs pop_size + 1 evaluations per generation."""
+    return CMAESConfig(dimensions=dimensions).population_size + 1
+
+
+def gens_to_evals(gens: int, dimensions: int) -> int:
+    return gens * cmaes_evals_per_generation(dimensions)
+
+
+# ---------- family definitions ----------
+
+def build_family(family: str, rotation_seed: int = 42):
+    """Return (problems, dimensions, sigma, total_budget, memory, ls_settings).
+
+    ``ls_settings`` is a dict of L-BFGS-B kwargs to pass through.
+    """
+    if family == "baseline":
+        return {
+            "problems": [
+                ("Rastrigin", Rastrigin(10), 2.0),
+                ("Griewank",  Griewank(10),  200.0),
+            ],
+            "dimensions": 10,
+            "total_budget": 6000,
+            "memory_size": 10,
+            "ls_settings": dict(pgtol=1e-10, factr=0, line_search=LineSearchMethod.ARMIJO),
+        }
+    if family == "reproduce_old":
+        base = RippledEllipsoid(50, condition=1e6, amplitude=0.0)
+        return {
+            "problems": [
+                ("Ellipsoid-rot-d50",
+                 RotatedFunction(base, rotation="random", seed=rotation_seed),
+                 10.0),
+            ],
+            "dimensions": 50,
+            "total_budget": 10000,
+            "memory_size": 5,
+            "ls_settings": dict(pgtol=1e-8, factr=1e7, line_search=LineSearchMethod.ARMIJO),
+        }
+    if family == "low_amp":
+        base = RippledEllipsoid(30, condition=1e6, amplitude=0.1)
+        return {
+            "problems": [
+                ("RippledEllipsoid-a0.1-rot-d30",
+                 RotatedFunction(base, rotation="random", seed=rotation_seed),
+                 2.0),
+            ],
+            "dimensions": 30,
+            "total_budget": 10000,
+            "memory_size": 5,
+            "ls_settings": dict(pgtol=1e-10, factr=0, line_search=LineSearchMethod.ARMIJO),
+        }
+    if family == "multimodal":
+        base = RippledEllipsoid(50, condition=1e6, amplitude=1.0)
+        return {
+            "problems": [
+                ("RippledEllipsoid-a1-rot-d50",
+                 RotatedFunction(base, rotation="random", seed=rotation_seed),
+                 2.0),
+            ],
+            "dimensions": 50,
+            "total_budget": 10000,
+            "memory_size": 5,
+            "ls_settings": dict(pgtol=1e-8, factr=1e7, line_search=LineSearchMethod.ARMIJO),
+        }
+    raise ValueError(f"unknown family {family!r}")
+
+
+def default_warmup_gens(family: str) -> list[int]:
+    """Generations to use as the timing-sweep axis per family."""
+    return {
+        "baseline":       [10, 30, 75, 150, 300],
+        "reproduce_old":  [20, 75, 150, 300, 500],
+        "low_amp":        [50, 100, 200, 350, 500],
+        "multimodal":     [30, 75, 150, 250, 400],
+    }[family]
+
+
+# ---------- algorithm construction ----------
+
+def build_algorithms(
+    family_cfg: dict,
+    warmup_gens_list: list[int],
+    initial_sigma: float,
+):
+    dimensions = family_cfg["dimensions"]
+    total_budget = family_cfg["total_budget"]
+    memory_size = family_cfg["memory_size"]
+    ls_settings = family_cfg["ls_settings"]
+
+    lbfgsb_kwargs = dict(**ls_settings, m=memory_size)
+
+    cmaes_only = SingleAlgorithm(
+        name="CMA-ES",
+        color=REFERENCE_COLORS["CMA-ES"],
+        algorithm=AlgorithmChoice.CMAES,
+        config_factory=lambda d: CMAESConfig(
+            dimensions=d, budget=total_budget, sigma=initial_sigma,
+        ),
+    )
+
+    lbfgsb_only = SingleAlgorithm(
+        name="L-BFGS-B",
+        color=REFERENCE_COLORS["L-BFGS-B"],
+        algorithm=AlgorithmChoice.LBFGSB,
+        config_factory=lambda d: LBFGSBConfig(
+            dimensions=d, budget=total_budget, **lbfgsb_kwargs,
+        ),
+    )
+
+    handoffs: list[CMAESLBFGSBHandoff] = []
+    for idx, warmup_gens in enumerate(warmup_gens_list):
+        warmup_evals = gens_to_evals(warmup_gens, dimensions)
+        post = total_budget - warmup_evals
+        if post <= 0:
+            raise ValueError(
+                f"warmup {warmup_gens} gen ({warmup_evals} evals) >= total {total_budget}"
+            )
+
+        handoffs.append(CMAESLBFGSBHandoff(
+            name=f"C^-1 @ {warmup_gens} gen",
+            color=PALETTE_INVERSE[idx % len(PALETTE_INVERSE)],
+            cmaes_config_factory=lambda d, b=warmup_evals: CMAESConfig(
+                dimensions=d, budget=b, sigma=initial_sigma,
+            ),
+            lbfgsb_config_factory=lambda d, b=post: LBFGSBConfig(
+                dimensions=d, budget=b, **lbfgsb_kwargs,
+            ),
+            transform="inverse",
+        ))
+        handoffs.append(CMAESLBFGSBHandoff(
+            name=f"identity @ {warmup_gens} gen",
+            color=PALETTE_IDENTITY[idx % len(PALETTE_IDENTITY)],
+            cmaes_config_factory=lambda d, b=warmup_evals: CMAESConfig(
+                dimensions=d, budget=b, sigma=initial_sigma,
+            ),
+            lbfgsb_config_factory=lambda d, b=post: LBFGSBConfig(
+                dimensions=d, budget=b, **lbfgsb_kwargs,
+            ),
+            transform="identity",
+        ))
+
+    return [cmaes_only, lbfgsb_only, *handoffs]
+
+
+def run(
+    family: str,
+    warmup_gens_list: list[int],
+    num_seeds: int,
+    num_workers: int,
+    output_dir: Path,
+    rotation_seed: int = 42,
+) -> None:
+    cfg = build_family(family, rotation_seed)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    problems: list[Problem] = []
+    for name, func, _sigma in cfg["problems"]:
+        problems.append(Problem.from_benchmark(name, func))
+
+    combined_traces: dict = {}
+    representative_algorithms: list = []
+
+    for (name, func, sigma), problem in zip(cfg["problems"], problems):
+        algorithms = build_algorithms(cfg, warmup_gens_list, initial_sigma=sigma)
+
+        bench = Benchmark(
+            problems=[problem],
+            algorithms=algorithms,
+            seeds=list(range(num_seeds)),
+            output_dir=output_dir / problem.name,
+            num_workers=num_workers,
+        )
+        bench.run(verbose=True)
+        bench.print_summary()
+
+        for key, traces in bench.traces.items():
+            combined_traces[key] = traces
+        # Reuse the algorithm list metadata (name + color) for plotting.
+        if not representative_algorithms:
+            representative_algorithms = algorithms
+
+    plotter = BenchmarkPlotter(
+        problems=problems,
+        algorithms=representative_algorithms,
+        traces=combined_traces,
+        output_dir=output_dir,
+        floor=1e-22 if family == "low_amp" else 1e-12,
+    )
+
+    # Per-family title and per-panel aspect
+    titles = {
+        "baseline":      "Handoff timing — baseline (Rastrigin, Griewank d=10, m=10)",
+        "reproduce_old": "Handoff timing — pure rotated Ellipsoid d=50, m=5",
+        "low_amp":       "Handoff timing — rotated RippledEllipsoid amp=0.1 d=30 m=5",
+        "multimodal":    "Handoff timing — rotated RippledEllipsoid amp=1 d=50 m=5",
+    }
+    plotter.plot_convergence_grid(
+        save_path=output_dir / "convergence.png",
+        title=titles[family],
+        show_iqr=False,
+        figsize_per_panel=(9.5, 6.5),
+        legend_fontsize=8,
+    )
+
+    print(f"\nWrote {output_dir}/convergence.png")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--family", required=True,
+        choices=("baseline", "reproduce_old", "low_amp", "multimodal"),
+    )
+    parser.add_argument(
+        "--warmup-gens", type=int, nargs="+", default=None,
+        help="CMA-ES generations to use as warmup timings. Defaults to a sensible per-family list.",
+    )
+    parser.add_argument("--num-seeds", type=int, default=15)
+    parser.add_argument("--num-workers", type=int, default=6)
+    parser.add_argument("--rotation-seed", type=int, default=42)
+    parser.add_argument("--output-dir", type=Path, default=None)
+    args = parser.parse_args()
+
+    if args.warmup_gens is None:
+        args.warmup_gens = default_warmup_gens(args.family)
+
+    if args.output_dir is None:
+        args.output_dir = Path(f"plots/report/timing_{args.family}")
+
+    run(
+        family=args.family,
+        warmup_gens_list=sorted(args.warmup_gens),
+        num_seeds=args.num_seeds,
+        num_workers=args.num_workers,
+        output_dir=args.output_dir,
+        rotation_seed=args.rotation_seed,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/regen_report_plots.py
+++ b/examples/regen_report_plots.py
@@ -1,0 +1,294 @@
+"""Regenerate the 5 report plots from saved traces.
+
+Reads `traces.json` from each `plots/report/<panel>/` directory and re-renders
+the convergence + boxplot at a single, consistent visual style suitable for
+the supervisor report. No re-running of optimizers needed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+
+from src.benchmarking.persistence import load_traces_json
+from src.benchmarking.plotter import BenchmarkPlotter
+from src.benchmarking.problem import Problem
+from src.benchmarking.algorithm_run import AlgorithmRun, SingleAlgorithm
+from src.algorithms.choices import AlgorithmChoice
+
+# Algorithm-name -> display color (keep stable across all report plots)
+COLOR_MAP = {
+    "CMA-ES":                          "#e74c3c",
+    "L-BFGS-B":                        "#3498db",
+    "CMA-ES -> L-BFGS-B (C^-1)":       "#2ecc71",
+    "CMA-ES -> L-BFGS-B (identity)":   "#9b59b6",
+    "Handoff (C^-1)":                  "#2ecc71",
+    "Handoff (identity)":              "#9b59b6",
+}
+
+
+@dataclass
+class StubAlgorithm:
+    """Minimal AlgorithmRun-shaped object for re-plotting (no `run` method).
+
+    Plotter only needs ``name`` and ``color`` from each algorithm spec, so
+    we don't need to reconstruct the actual config_factory closures.
+    """
+    name: str
+    color: str
+
+    def run(self, *a, **kw):  # pragma: no cover - never called during replot
+        raise NotImplementedError
+
+
+def stub_problem(name: str, dimensions: int) -> Problem:
+    """Plotter only needs ``name`` and ``dimensions`` from Problem; everything
+    else is bypassed because we already have the traces."""
+    return Problem(
+        name=name,
+        function=lambda x: 0.0,
+        dimensions=dimensions,
+        lower_bound=-1.0,
+        upper_bound=1.0,
+    )
+
+
+def regen_panel(
+    traces_dir: Path,
+    save_dir: Path,
+    title: str,
+    boxplot_title: str | None = None,
+    panel_aspect: tuple[float, float] = (10.0, 6.5),
+    legend_fontsize: int = 11,
+    floor: float = 1e-12,
+) -> None:
+    """Re-render convergence and final-fitness boxplot for a single panel."""
+    save_dir.mkdir(parents=True, exist_ok=True)
+    traces_file = traces_dir / "traces.json"
+
+    traces = load_traces_json(traces_file)
+    # Order matters for the legend. Use the order we encounter the algorithm
+    # names. Sort so reference algorithms come first.
+    seen_names: list[str] = []
+    problem_dims: dict[str, int] = {}
+    for (problem_name, algorithm_name), runs in traces.items():
+        if algorithm_name not in seen_names:
+            seen_names.append(algorithm_name)
+        if runs:
+            # Infer dimension from anywhere -- the problem name has it embedded
+            # in our convention (e.g. "Rippled-c1000000-a0.1-rot-d50-m5").
+            # Default to 0 if we can't parse it.
+            try:
+                token = next(t for t in problem_name.split("-") if t.startswith("d"))
+                problem_dims[problem_name] = int(token[1:])
+            except (StopIteration, ValueError):
+                problem_dims[problem_name] = 0
+
+    # Reorder: CMA-ES, L-BFGS-B, then handoffs (C^-1 first, identity second).
+    priority = {
+        "CMA-ES": 0,
+        "L-BFGS-B": 1,
+    }
+    def name_key(name: str) -> tuple[int, str]:
+        if name in priority:
+            return (priority[name], name)
+        if "C^-1" in name:
+            return (10, name)
+        if "identity" in name:
+            return (11, name)
+        return (20, name)
+    seen_names.sort(key=name_key)
+
+    algorithms = [
+        StubAlgorithm(name=n, color=COLOR_MAP.get(n, "#7f8c8d"))
+        for n in seen_names
+    ]
+
+    problems = [
+        stub_problem(p_name, problem_dims.get(p_name, 0))
+        for p_name in sorted(set(p for p, _ in traces.keys()))
+    ]
+
+    plotter = BenchmarkPlotter(
+        problems=problems,
+        algorithms=algorithms,
+        traces=traces,
+        output_dir=save_dir,
+        floor=floor,
+    )
+
+    plotter.plot_convergence_grid(
+        save_path=save_dir / "convergence.png",
+        title=title,
+        figsize_per_panel=panel_aspect,
+        legend_fontsize=legend_fontsize,
+    )
+
+    if boxplot_title is not None:
+        plotter.plot_final_fitness_boxplot(
+            save_path=save_dir / "final_fitness.png",
+            title=boxplot_title,
+        )
+
+    plt.close("all")
+    print(f"  Wrote {save_dir}/convergence.png" + (
+        f" + {save_dir}/final_fitness.png" if boxplot_title else ""
+    ))
+
+
+def main() -> None:
+    plt.rcParams.update({
+        "font.family": "sans-serif",
+        "axes.spines.top": False,
+        "axes.spines.right": False,
+    })
+
+    base = Path("plots/report")
+
+    # ---- Plot 0: baseline (unrotated multimodal) ----
+    # Re-loads from the per-problem subdirs; this benchmark wrote two panels.
+    regen_combined_baseline(base)
+
+    # ---- Plot 1: rotated near-unimodal, three dimensions ----
+    regen_combined_low_amp(base)
+
+    # ---- Plot 2: pure rotated ellipsoid (reproduction of old finding) ----
+    regen_panel(
+        traces_dir=base / "02_reproduce_old" / "Rippled-c1000000-a0-rot-d50-m5",
+        save_dir=base / "02_reproduce_old",
+        title="Pure rotated Ellipsoid d=50, cond=10⁶, m=5  —  loose L-BFGS-B termination",
+        boxplot_title="Final fitness (pure rotated Ellipsoid)",
+        panel_aspect=(11.0, 6.5),
+    )
+
+    # ---- Plot 3: multimodal anisotropic with tight budget ----
+    regen_panel(
+        traces_dir=base / "03_multimodal_tight" / "Rippled-c1000000-a1-rot-d50-m5",
+        save_dir=base / "03_multimodal_tight",
+        title="Rotated RippledEllipsoid d=50, cond=10⁶, amp=1, m=5  —  warmup 5000 / L-BFGS-B 1000",
+        boxplot_title="Final fitness (multimodal, tight budget)",
+        panel_aspect=(11.0, 6.5),
+    )
+
+    # ---- Plot 4: warmup timing sweep ----
+    regen_panel(
+        traces_dir=base / "04_timing_sweep",
+        save_dir=base / "04_timing_sweep",
+        title="Warmup timing sweep  —  rotated RippledEllipsoid d=30, cond=10⁶, amp=0.1, m=5",
+        boxplot_title=None,
+        panel_aspect=(12.0, 7.0),
+        legend_fontsize=9,
+    )
+
+    print("All report plots regenerated.")
+
+
+def regen_combined_baseline(base: Path) -> None:
+    """Combine Rastrigin and Griewank baseline traces into one 2-panel figure."""
+    combined: dict = {}
+    problem_dims: dict[str, int] = {}
+    seen_names: list[str] = []
+
+    for problem_name in ("rastrigin", "griewank"):
+        path = base / "00_baseline_unrotated" / problem_name / "traces.json"
+        if not path.exists():
+            print(f"  [skip] missing {path}")
+            return
+        per_problem = load_traces_json(path)
+        for (p, a), runs in per_problem.items():
+            combined.setdefault((p, a), []).extend(runs)
+            if a not in seen_names:
+                seen_names.append(a)
+            problem_dims[p] = runs[0].evaluations and 10 or 10  # known d=10
+
+    def name_key(name: str) -> tuple[int, str]:
+        if name == "CMA-ES":           return (0, name)
+        if name == "L-BFGS-B":         return (1, name)
+        if "C^-1" in name:             return (10, name)
+        if "identity" in name:         return (11, name)
+        return (20, name)
+    seen_names.sort(key=name_key)
+
+    algorithms = [StubAlgorithm(name=n, color=COLOR_MAP.get(n, "#7f8c8d")) for n in seen_names]
+
+    problem_names = sorted(set(p for p, _ in combined.keys()))
+    problems = [stub_problem(p, problem_dims.get(p, 10)) for p in problem_names]
+
+    plotter = BenchmarkPlotter(
+        problems=problems,
+        algorithms=algorithms,
+        traces=combined,
+        output_dir=base / "00_baseline_unrotated",
+    )
+    plotter.plot_convergence_grid(
+        save_path=base / "00_baseline_unrotated" / "convergence.png",
+        title="Baseline: unrotated Rastrigin and Griewank, d=10  —  identity matches C⁻¹",
+        figsize_per_panel=(9.0, 6.5),
+        legend_fontsize=10,
+    )
+    plotter.plot_final_fitness_boxplot(
+        save_path=base / "00_baseline_unrotated" / "final_fitness.png",
+        title="Final fitness (baseline, unrotated)",
+    )
+    plt.close("all")
+    print(f"  Wrote {base/'00_baseline_unrotated'}/convergence.png + boxplot")
+
+
+def regen_combined_low_amp(base: Path) -> None:
+    """Combine d=10, d=30, d=50 traces of rotated low-ripple RippledEllipsoid."""
+    combined: dict = {}
+    problem_dims: dict[str, int] = {}
+    seen_names: list[str] = []
+
+    panels = [
+        ("Rippled-c1000000-a0.1-rot-d10-m5", 10),
+        ("Rippled-c1000000-a0.1-rot-d30-m5", 30),
+        ("Rippled-c1000000-a0.1-rot-d50-m5", 50),
+    ]
+    for subdir_name, d in panels:
+        path = base / "01_rippled_low_amp" / subdir_name / "traces.json"
+        if not path.exists():
+            print(f"  [skip] missing {path}")
+            return
+        per = load_traces_json(path)
+        for (p, a), runs in per.items():
+            combined.setdefault((p, a), []).extend(runs)
+            if a not in seen_names:
+                seen_names.append(a)
+            problem_dims[p] = d
+
+    def name_key(name: str) -> tuple[int, str]:
+        if name == "CMA-ES":           return (0, name)
+        if name == "L-BFGS-B":         return (1, name)
+        if "C^-1" in name:             return (10, name)
+        if "identity" in name:         return (11, name)
+        return (20, name)
+    seen_names.sort(key=name_key)
+
+    algorithms = [StubAlgorithm(name=n, color=COLOR_MAP.get(n, "#7f8c8d")) for n in seen_names]
+
+    problem_names = sorted(set(p for p, _ in combined.keys()),
+                          key=lambda n: problem_dims.get(n, 0))
+    problems = [stub_problem(p, problem_dims.get(p, 0)) for p in problem_names]
+
+    plotter = BenchmarkPlotter(
+        problems=problems,
+        algorithms=algorithms,
+        traces=combined,
+        output_dir=base / "01_rippled_low_amp",
+        floor=1e-22,  # values reach 1e-20 here; the default 1e-12 would clip C^-1
+    )
+    plotter.plot_convergence_grid(
+        save_path=base / "01_rippled_low_amp" / "convergence.png",
+        title="Rotated RippledEllipsoid, cond=10⁶, amp=0.1, m=5  —  C⁻¹ wins by orders of magnitude",
+        figsize_per_panel=(8.0, 6.0),
+        legend_fontsize=9,
+    )
+    plt.close("all")
+    print(f"  Wrote {base/'01_rippled_low_amp'}/convergence.png")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rippled_ellipsoid_handoff.py
+++ b/examples/rippled_ellipsoid_handoff.py
@@ -1,0 +1,268 @@
+"""Anisotropic multimodal handoff study.
+
+Built on top of RippledEllipsoid:
+
+    f(x) = sum(scale_i * x_i**2 + amplitude * (1 - cos(2 pi x_i)))
+
+When the condition number is large the local Hessian at the global
+optimum spans many orders of magnitude; when the rotation is non-trivial
+that anisotropy is no longer axis-aligned. This is the regime where
+L-BFGS-B with B_0 = I is forced to spend many iterations learning the
+curvature, and where the C^{-1} handoff from CMA-ES should pull
+decisively ahead.
+
+The script sweeps a configurable grid of (dimension, memory size,
+condition number) and produces a combined convergence + boxplot pair.
+"""
+
+import argparse
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+
+from src.algorithms.choices import AlgorithmChoice
+from src.algorithms.cmaes.config import CMAESConfig
+from src.algorithms.lbfgsb.config import LBFGSBConfig, LineSearchMethod
+from src.benchmarking import (
+    Benchmark,
+    BenchmarkPlotter,
+    CMAESLBFGSBHandoff,
+    Problem,
+    SingleAlgorithm,
+)
+from src.utils.benchmark_functions import RippledEllipsoid, RotatedFunction
+
+
+plt.ioff()
+plt.switch_backend("Agg")
+
+
+COLORS = {
+    "CMA-ES":             "#e74c3c",
+    "L-BFGS-B":           "#3498db",
+    "Handoff (C^-1)":     "#2ecc71",
+    "Handoff (identity)": "#9b59b6",
+}
+
+
+def build_function(
+    dimensions: int,
+    condition: float,
+    rotated: bool,
+    rotation_seed: int,
+    amplitude: float = 10.0,
+):
+    base = RippledEllipsoid(
+        dimensions, condition=condition, amplitude=amplitude, bound=5.12
+    )
+    if not rotated:
+        return base
+    return RotatedFunction(base, rotation="random", seed=rotation_seed)
+
+
+def build_algorithms(
+    total_budget: int,
+    cmaes_warmup_budget: int,
+    initial_sigma: float,
+    memory_size: int,
+    pgtol: float = 1e-10,
+    factr: float = 0.0,
+):
+    lbfgsb_handoff_budget = total_budget - cmaes_warmup_budget
+
+    common_lbfgsb_kwargs = dict(
+        m=memory_size, pgtol=pgtol, factr=factr,
+        line_search=LineSearchMethod.ARMIJO,
+    )
+
+    cmaes_only = SingleAlgorithm(
+        name="CMA-ES",
+        color=COLORS["CMA-ES"],
+        algorithm=AlgorithmChoice.CMAES,
+        config_factory=lambda d: CMAESConfig(
+            dimensions=d, budget=total_budget, sigma=initial_sigma,
+        ),
+    )
+
+    lbfgsb_only = SingleAlgorithm(
+        name="L-BFGS-B",
+        color=COLORS["L-BFGS-B"],
+        algorithm=AlgorithmChoice.LBFGSB,
+        config_factory=lambda d: LBFGSBConfig(
+            dimensions=d, budget=total_budget, **common_lbfgsb_kwargs,
+        ),
+    )
+
+    handoff_inverse = CMAESLBFGSBHandoff(
+        name="Handoff (C^-1)",
+        color=COLORS["Handoff (C^-1)"],
+        cmaes_config_factory=lambda d: CMAESConfig(
+            dimensions=d, budget=cmaes_warmup_budget, sigma=initial_sigma,
+        ),
+        lbfgsb_config_factory=lambda d: LBFGSBConfig(
+            dimensions=d, budget=lbfgsb_handoff_budget, **common_lbfgsb_kwargs,
+        ),
+        transform="inverse",
+    )
+
+    handoff_identity = CMAESLBFGSBHandoff(
+        name="Handoff (identity)",
+        color=COLORS["Handoff (identity)"],
+        cmaes_config_factory=lambda d: CMAESConfig(
+            dimensions=d, budget=cmaes_warmup_budget, sigma=initial_sigma,
+        ),
+        lbfgsb_config_factory=lambda d: LBFGSBConfig(
+            dimensions=d, budget=lbfgsb_handoff_budget, **common_lbfgsb_kwargs,
+        ),
+        transform="identity",
+    )
+
+    return [cmaes_only, lbfgsb_only, handoff_inverse, handoff_identity]
+
+
+def run_one_panel(
+    dimensions: int,
+    condition: float,
+    memory_size: int,
+    rotated: bool,
+    total_budget: int,
+    cmaes_warmup_budget: int,
+    num_seeds: int,
+    rotation_seed: int,
+    num_workers: int,
+    output_dir: Path,
+    amplitude: float = 10.0,
+    pgtol: float = 1e-10,
+    factr: float = 0.0,
+    initial_sigma: float = 2.0,
+) -> tuple[Problem, list, dict]:
+    function = build_function(
+        dimensions, condition, rotated, rotation_seed, amplitude=amplitude
+    )
+    rotated_tag = "rot" if rotated else "axis"
+    amp_tag = f"a{amplitude:g}"
+    panel_name = (
+        f"Rippled-c{int(condition)}-{amp_tag}-{rotated_tag}"
+        f"-d{dimensions}-m{memory_size}"
+    )
+    problem = Problem.from_benchmark(panel_name, function)
+
+    # Initial sigma should scale with the bound. RippledEllipsoid has bound 5.12.
+    algorithms = build_algorithms(
+        total_budget=total_budget,
+        cmaes_warmup_budget=cmaes_warmup_budget,
+        initial_sigma=initial_sigma,
+        memory_size=memory_size,
+        pgtol=pgtol,
+        factr=factr,
+    )
+
+    bench = Benchmark(
+        problems=[problem],
+        algorithms=algorithms,
+        seeds=list(range(num_seeds)),
+        output_dir=output_dir / panel_name,
+        num_workers=num_workers,
+    )
+    bench.run(verbose=True)
+    bench.print_summary()
+    return problem, algorithms, bench.traces
+
+
+def render_combined(panels, output_dir: Path, title: str) -> None:
+    problems = [p for p, _, _ in panels]
+    representative_algorithms = panels[0][1]
+    combined_traces: dict = {}
+    for _, _, traces in panels:
+        for key, value in traces.items():
+            combined_traces[key] = value
+
+    plotter = BenchmarkPlotter(
+        problems=problems,
+        algorithms=representative_algorithms,
+        traces=combined_traces,
+        output_dir=output_dir,
+    )
+    plotter.plot_convergence_grid(
+        save_path=output_dir / "convergence.png",
+        title=title,
+    )
+    plotter.plot_final_fitness_boxplot(
+        save_path=output_dir / "final_fitness.png",
+        title=f"Final fitness distribution ({title})",
+    )
+    print(f"\nCombined plot saved to {output_dir.absolute()}/convergence.png")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dimensions", type=int, nargs="+", default=[10, 30])
+    parser.add_argument("--conditions", type=float, nargs="+", default=[1000.0])
+    parser.add_argument("--memory", type=int, nargs="+", default=[5])
+    parser.add_argument(
+        "--amplitude", type=float, default=10.0,
+        help="Ripple amplitude. Lower = less multimodal but better conditioned for L-BFGS-B; default 10 (Rastrigin-like).",
+    )
+    parser.add_argument(
+        "--rotated", action="store_true", default=True,
+        help="Use rotated functions (default true; pass --no-rotated to disable).",
+    )
+    parser.add_argument("--no-rotated", dest="rotated", action="store_false")
+    parser.add_argument("--total-budget", type=int, default=10000)
+    parser.add_argument("--cmaes-warmup-budget", type=int, default=2500)
+    parser.add_argument("--num-seeds", type=int, default=15)
+    parser.add_argument("--rotation-seed", type=int, default=42)
+    parser.add_argument("--num-workers", type=int, default=4)
+    parser.add_argument(
+        "--pgtol", type=float, default=1e-10,
+        help="L-BFGS-B projected gradient tolerance (looser = earlier stop).",
+    )
+    parser.add_argument(
+        "--factr", type=float, default=0.0,
+        help="L-BFGS-B f-value relative tolerance factor (0 disables).",
+    )
+    parser.add_argument(
+        "--initial-sigma", type=float, default=2.0,
+        help="Initial sigma for CMA-ES.",
+    )
+    parser.add_argument(
+        "--output-dir", type=Path,
+        default=Path("plots/hybrid/rippled_ellipsoid_handoff"),
+    )
+    args = parser.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    panels: list = []
+    for d in args.dimensions:
+        for cond in args.conditions:
+            for m in args.memory:
+                panels.append(
+                    run_one_panel(
+                        dimensions=d,
+                        condition=cond,
+                        memory_size=m,
+                        rotated=args.rotated,
+                        total_budget=args.total_budget,
+                        cmaes_warmup_budget=args.cmaes_warmup_budget,
+                        num_seeds=args.num_seeds,
+                        rotation_seed=args.rotation_seed,
+                        num_workers=args.num_workers,
+                        output_dir=args.output_dir,
+                        amplitude=args.amplitude,
+                        pgtol=args.pgtol,
+                        factr=args.factr,
+                        initial_sigma=args.initial_sigma,
+                    )
+                )
+
+    rot_str = "rotated" if args.rotated else "axis-aligned"
+    title = (
+        f"Rippled Ellipsoid ({rot_str}): C^-1 vs identity handoff "
+        f"({args.num_seeds} seeds, budget {args.total_budget}, warmup {args.cmaes_warmup_budget})"
+    )
+    render_combined(panels, args.output_dir, title)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rippled_handoff_timing_sweep.py
+++ b/examples/rippled_handoff_timing_sweep.py
@@ -1,0 +1,178 @@
+"""Handoff timing sweep on rotated RippledEllipsoid.
+
+Goal: show how much CMA-ES warmup is needed for the covariance to become
+informative. Sweeps the warmup budget while keeping total budget fixed.
+Compares C^-1 handoff against identity handoff at each timing.
+
+Use this together with ``rippled_ellipsoid_handoff.py`` to motivate when
+the covariance handoff is worth doing.
+"""
+
+import argparse
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+
+from src.algorithms.choices import AlgorithmChoice
+from src.algorithms.cmaes.config import CMAESConfig
+from src.algorithms.lbfgsb.config import LBFGSBConfig, LineSearchMethod
+from src.benchmarking import (
+    Benchmark,
+    BenchmarkPlotter,
+    CMAESLBFGSBHandoff,
+    Problem,
+    SingleAlgorithm,
+)
+from src.utils.benchmark_functions import RippledEllipsoid, RotatedFunction
+
+
+plt.ioff()
+plt.switch_backend("Agg")
+
+
+PALETTE_INVERSE = ["#a8e6c9", "#74c69d", "#40916c", "#2d6a4f", "#1b4332"]
+PALETTE_IDENTITY = ["#dcd0ff", "#b39ddb", "#9575cd", "#7e57c2", "#5e35b1"]
+
+REFERENCE_COLORS = {
+    "CMA-ES":   "#e74c3c",
+    "L-BFGS-B": "#3498db",
+}
+
+
+def build_problem(d: int, condition: float, amplitude: float, rotation_seed: int):
+    base = RippledEllipsoid(d, condition=condition, amplitude=amplitude)
+    rotated = RotatedFunction(base, rotation="random", seed=rotation_seed)
+    return Problem.from_benchmark(
+        f"RippledEllipsoid-c{int(condition)}-a{amplitude:g}-d{d}", rotated
+    )
+
+
+def build_algorithms(
+    total_budget: int,
+    warmup_budgets: list[int],
+    memory_size: int,
+    initial_sigma: float,
+):
+    lbfgsb_kwargs = dict(
+        m=memory_size, pgtol=1e-10, factr=0,
+        line_search=LineSearchMethod.ARMIJO,
+    )
+
+    cmaes_only = SingleAlgorithm(
+        name="CMA-ES",
+        color=REFERENCE_COLORS["CMA-ES"],
+        algorithm=AlgorithmChoice.CMAES,
+        config_factory=lambda d: CMAESConfig(
+            dimensions=d, budget=total_budget, sigma=initial_sigma,
+        ),
+    )
+
+    lbfgsb_only = SingleAlgorithm(
+        name="L-BFGS-B",
+        color=REFERENCE_COLORS["L-BFGS-B"],
+        algorithm=AlgorithmChoice.LBFGSB,
+        config_factory=lambda d: LBFGSBConfig(
+            dimensions=d, budget=total_budget, **lbfgsb_kwargs,
+        ),
+    )
+
+    handoffs = []
+    for idx, warmup in enumerate(warmup_budgets):
+        post = total_budget - warmup
+        # C^-1
+        handoffs.append(
+            CMAESLBFGSBHandoff(
+                name=f"C^-1 warmup={warmup}",
+                color=PALETTE_INVERSE[idx % len(PALETTE_INVERSE)],
+                cmaes_config_factory=lambda d, w=warmup: CMAESConfig(
+                    dimensions=d, budget=w, sigma=initial_sigma,
+                ),
+                lbfgsb_config_factory=lambda d, p=post: LBFGSBConfig(
+                    dimensions=d, budget=p, **lbfgsb_kwargs,
+                ),
+                transform="inverse",
+            )
+        )
+        # Identity
+        handoffs.append(
+            CMAESLBFGSBHandoff(
+                name=f"identity warmup={warmup}",
+                color=PALETTE_IDENTITY[idx % len(PALETTE_IDENTITY)],
+                cmaes_config_factory=lambda d, w=warmup: CMAESConfig(
+                    dimensions=d, budget=w, sigma=initial_sigma,
+                ),
+                lbfgsb_config_factory=lambda d, p=post: LBFGSBConfig(
+                    dimensions=d, budget=p, **lbfgsb_kwargs,
+                ),
+                transform="identity",
+            )
+        )
+    return [cmaes_only, lbfgsb_only, *handoffs]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dimensions", type=int, default=30)
+    parser.add_argument("--condition", type=float, default=1e6)
+    parser.add_argument("--amplitude", type=float, default=0.1)
+    parser.add_argument("--memory-size", type=int, default=5)
+    parser.add_argument("--total-budget", type=int, default=10000)
+    parser.add_argument(
+        "--warmup-budgets", type=int, nargs="+",
+        default=[500, 1500, 3000, 5000, 7500],
+    )
+    parser.add_argument("--num-seeds", type=int, default=15)
+    parser.add_argument("--num-workers", type=int, default=6)
+    parser.add_argument("--rotation-seed", type=int, default=42)
+    parser.add_argument(
+        "--output-dir", type=Path,
+        default=Path("plots/hybrid/rippled_handoff_timing_sweep"),
+    )
+    args = parser.parse_args()
+
+    problem = build_problem(
+        args.dimensions, args.condition, args.amplitude, args.rotation_seed
+    )
+
+    algorithms = build_algorithms(
+        total_budget=args.total_budget,
+        warmup_budgets=sorted(args.warmup_budgets),
+        memory_size=args.memory_size,
+        initial_sigma=2.0,
+    )
+
+    bench = Benchmark(
+        problems=[problem],
+        algorithms=algorithms,
+        seeds=list(range(args.num_seeds)),
+        output_dir=args.output_dir,
+        num_workers=args.num_workers,
+    )
+    bench.run(verbose=True)
+    bench.print_summary()
+
+    plotter = BenchmarkPlotter(
+        problems=[problem],
+        algorithms=algorithms,
+        traces=bench.traces,
+        output_dir=args.output_dir,
+    )
+    plotter.plot_convergence_grid(
+        save_path=args.output_dir / "convergence.png",
+        title=(
+            f"Handoff timing on RippledEllipsoid (cond={args.condition:.0e}, "
+            f"amp={args.amplitude}, d={args.dimensions}, m={args.memory_size}, "
+            f"{args.num_seeds} seeds)"
+        ),
+        show_iqr=False,
+    )
+    plotter.plot_final_fitness_boxplot(
+        save_path=args.output_dir / "final_fitness.png",
+        title=f"Final fitness vs warmup timing",
+    )
+
+    print(f"\nPlots saved to {args.output_dir.absolute()}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rotated_multimodal_handoff.py
+++ b/examples/rotated_multimodal_handoff.py
@@ -1,0 +1,260 @@
+"""Does the CMA-ES covariance actually help when L-BFGS-B takes over?
+
+In the unrotated Rastrigin/Griewank run, the C^{-1} handoff and the
+identity handoff converged to the same final fitness in the same number
+of evaluations. The reason: at every Rastrigin local minimum the
+Hessian is *exactly isotropic* (eigenvalues all 2 + 40 pi^2), so there
+is no curvature direction for CMA-ES to learn. Griewank does have
+anisotropic curvature (cond ~ d), but in the coordinate-aligned form
+identity + a few BFGS corrections recovers it just as quickly.
+
+This script tests the case where the covariance *must* matter:
+
+  - Rotate Griewank with a random orthogonal matrix. The eigenvalues of
+    the local Hessian stay the same (cond ~ d) but they're no longer
+    axis-aligned. Identity B_0 starts blind to the rotation.
+
+  - Push dimension up so that the L-BFGS-B memory size m is small
+    relative to d: corrections can span at most m directions, so the
+    remaining d - m have to come from B_0.
+
+  - Vary handoff timing to find the point at which CMA-ES has learned
+    enough of the rotation to be useful.
+
+Sweeps are configurable from the CLI. The default sweep produces the
+plot grid for the supervisor report.
+"""
+
+import argparse
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+
+from src.algorithms.choices import AlgorithmChoice
+from src.algorithms.cmaes.config import CMAESConfig
+from src.algorithms.lbfgsb.config import LBFGSBConfig, LineSearchMethod
+from src.benchmarking import (
+    Benchmark,
+    BenchmarkPlotter,
+    CMAESLBFGSBHandoff,
+    Problem,
+    SingleAlgorithm,
+)
+from src.utils.benchmark_functions import Griewank, Rastrigin, RotatedFunction
+
+
+plt.ioff()
+plt.switch_backend("Agg")
+
+
+COLORS = {
+    "CMA-ES":                          "#e74c3c",
+    "L-BFGS-B":                        "#3498db",
+    "Handoff (C^-1)":                  "#2ecc71",
+    "Handoff (identity)":              "#9b59b6",
+}
+
+
+def make_rotated(base_name: str, dimensions: int, rotation_seed: int):
+    """Return a RotatedFunction wrapping the named base function."""
+    base_cls = {"Griewank": Griewank, "Rastrigin": Rastrigin}[base_name]
+    base = base_cls(dimensions)
+    return RotatedFunction(base, rotation="random", seed=rotation_seed)
+
+
+def build_algorithms(
+    total_budget: int,
+    cmaes_warmup_budget: int,
+    initial_sigma: float,
+    memory_size: int,
+):
+    """Four algorithms: CMA-ES, L-BFGS-B, two handoffs (C^-1 vs identity)."""
+    lbfgsb_handoff_budget = total_budget - cmaes_warmup_budget
+
+    cmaes_only = SingleAlgorithm(
+        name="CMA-ES",
+        color=COLORS["CMA-ES"],
+        algorithm=AlgorithmChoice.CMAES,
+        config_factory=lambda d: CMAESConfig(
+            dimensions=d, budget=total_budget, sigma=initial_sigma,
+        ),
+    )
+
+    lbfgsb_only = SingleAlgorithm(
+        name="L-BFGS-B",
+        color=COLORS["L-BFGS-B"],
+        algorithm=AlgorithmChoice.LBFGSB,
+        config_factory=lambda d: LBFGSBConfig(
+            dimensions=d, budget=total_budget, m=memory_size,
+            pgtol=1e-10, factr=0,
+            line_search=LineSearchMethod.ARMIJO,
+        ),
+    )
+
+    handoff_inverse = CMAESLBFGSBHandoff(
+        name="Handoff (C^-1)",
+        color=COLORS["Handoff (C^-1)"],
+        cmaes_config_factory=lambda d: CMAESConfig(
+            dimensions=d, budget=cmaes_warmup_budget, sigma=initial_sigma,
+        ),
+        lbfgsb_config_factory=lambda d: LBFGSBConfig(
+            dimensions=d, budget=lbfgsb_handoff_budget, m=memory_size,
+            pgtol=1e-10, factr=0,
+            line_search=LineSearchMethod.ARMIJO,
+        ),
+        transform="inverse",
+    )
+
+    handoff_identity = CMAESLBFGSBHandoff(
+        name="Handoff (identity)",
+        color=COLORS["Handoff (identity)"],
+        cmaes_config_factory=lambda d: CMAESConfig(
+            dimensions=d, budget=cmaes_warmup_budget, sigma=initial_sigma,
+        ),
+        lbfgsb_config_factory=lambda d: LBFGSBConfig(
+            dimensions=d, budget=lbfgsb_handoff_budget, m=memory_size,
+            pgtol=1e-10, factr=0,
+            line_search=LineSearchMethod.ARMIJO,
+        ),
+        transform="identity",
+    )
+
+    return [cmaes_only, lbfgsb_only, handoff_inverse, handoff_identity]
+
+
+def sigma_for(base_name: str) -> float:
+    """Sensible initial sigma per problem (matches multimodal_handoff_benchmark)."""
+    if base_name == "Griewank":
+        return 200.0
+    if base_name == "Rastrigin":
+        return 2.0
+    raise ValueError(base_name)
+
+
+def run_one_panel(
+    base_name: str,
+    dimensions: int,
+    rotated: bool,
+    memory_size: int,
+    total_budget: int,
+    cmaes_warmup_budget: int,
+    num_seeds: int,
+    rotation_seed: int,
+    num_workers: int,
+    output_dir: Path,
+) -> tuple[Problem, list, dict]:
+    """One panel = one (function, d, rotated, m) configuration."""
+    function = (
+        make_rotated(base_name, dimensions, rotation_seed)
+        if rotated
+        else {"Griewank": Griewank, "Rastrigin": Rastrigin}[base_name](dimensions)
+    )
+    rotated_tag = "rot" if rotated else "axis"
+    panel_name = f"{base_name}-{rotated_tag}-d{dimensions}-m{memory_size}"
+    problem = Problem.from_benchmark(panel_name, function)
+
+    algorithms = build_algorithms(
+        total_budget=total_budget,
+        cmaes_warmup_budget=cmaes_warmup_budget,
+        initial_sigma=sigma_for(base_name),
+        memory_size=memory_size,
+    )
+
+    bench = Benchmark(
+        problems=[problem],
+        algorithms=algorithms,
+        seeds=list(range(num_seeds)),
+        output_dir=output_dir / panel_name,
+        num_workers=num_workers,
+    )
+    bench.run(verbose=True)
+    bench.print_summary()
+    return problem, algorithms, bench.traces
+
+
+def render_combined(
+    panels: list[tuple[Problem, list, dict]],
+    output_dir: Path,
+    title: str,
+    cmaes_warmup_budget: int,
+) -> None:
+    """Render all panels into one combined plot grid."""
+    problems = [p for p, _, _ in panels]
+    representative_algorithms = panels[0][1]
+    combined_traces: dict = {}
+    for _, _, traces in panels:
+        for key, value in traces.items():
+            combined_traces[key] = value
+
+    plotter = BenchmarkPlotter(
+        problems=problems,
+        algorithms=representative_algorithms,
+        traces=combined_traces,
+        output_dir=output_dir,
+    )
+
+    plotter.plot_convergence_grid(
+        save_path=output_dir / "convergence.png",
+        title=title,
+    )
+    plotter.plot_final_fitness_boxplot(
+        save_path=output_dir / "final_fitness.png",
+        title=f"Final fitness distribution ({title})",
+    )
+    print(f"\nCombined plot saved to {output_dir.absolute()}/convergence.png")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--bases", nargs="+", default=["Griewank"],
+        help="Base function name(s): Griewank or Rastrigin (or both).",
+    )
+    parser.add_argument("--dimensions", type=int, nargs="+", default=[10, 30])
+    parser.add_argument("--memory", type=int, nargs="+", default=[10])
+    parser.add_argument(
+        "--rotated", action="store_true", default=True,
+        help="Use rotated functions (default true; pass --no-rotated to disable).",
+    )
+    parser.add_argument("--no-rotated", dest="rotated", action="store_false")
+    parser.add_argument("--total-budget", type=int, default=10000)
+    parser.add_argument("--cmaes-warmup-budget", type=int, default=2500)
+    parser.add_argument("--num-seeds", type=int, default=15)
+    parser.add_argument("--rotation-seed", type=int, default=42)
+    parser.add_argument("--num-workers", type=int, default=4)
+    parser.add_argument(
+        "--output-dir", type=Path,
+        default=Path("plots/hybrid/rotated_multimodal_handoff"),
+    )
+    args = parser.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    panels: list[tuple[Problem, list, dict]] = []
+    for base_name in args.bases:
+        for d in args.dimensions:
+            for m in args.memory:
+                panels.append(
+                    run_one_panel(
+                        base_name=base_name,
+                        dimensions=d,
+                        rotated=args.rotated,
+                        memory_size=m,
+                        total_budget=args.total_budget,
+                        cmaes_warmup_budget=args.cmaes_warmup_budget,
+                        num_seeds=args.num_seeds,
+                        rotation_seed=args.rotation_seed,
+                        num_workers=args.num_workers,
+                        output_dir=args.output_dir,
+                    )
+                )
+
+    title = (
+        f"Rotated multimodal handoff: C^-1 vs identity "
+        f"({args.num_seeds} seeds, budget {args.total_budget}, warmup {args.cmaes_warmup_budget})"
+    )
+    render_combined(panels, args.output_dir, title, args.cmaes_warmup_budget)
+
+
+if __name__ == "__main__":
+    main()

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:1930f9ccae3a070facbcc515edb7169546c134a8013c164c0c120c7dac76940d"
+content_hash = "sha256:8cd02cbac7c08145828c6960f63e97f3aecc95629c124bfcde02f42176c4426b"
 
 [[metadata.targets]]
 requires_python = "==3.12.*"
@@ -107,6 +107,17 @@ groups = ["default"]
 files = [
     {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
     {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
+]
+
+[[package]]
+name = "joblib"
+version = "1.5.3"
+requires_python = ">=3.9"
+summary = "Lightweight pipelining with Python functions"
+groups = ["default"]
+files = [
+    {file = "joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713"},
+    {file = "joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Default template for PDM package"
 authors = [
     {name = "Jedrzej Grabski", email = "grabski.dev@gmail.com"},
 ]
-dependencies = ["setuptools>=80.4.0", "numpy>=2.2.5", "matplotlib>=3.10.3", "scipy>=1.15.3", "opfunu>=1.0.1", "seaborn>=0.13.2"]
+dependencies = ["setuptools>=80.4.0", "numpy>=2.2.5", "matplotlib>=3.10.3", "scipy>=1.15.3", "opfunu>=1.0.1", "seaborn>=0.13.2", "joblib>=1.5.3"]
 requires-python = "==3.12.*"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/algorithms/cmaes/cmaes_optimizer.py
+++ b/src/algorithms/cmaes/cmaes_optimizer.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 
 @final
-class CMAESwOptimizer(BaseOptimizer["CMAESLogData", CMAESConfig]):
+class CMAESOptimizer(BaseOptimizer["CMAESLogData", CMAESConfig]):
     """CMA-ES optimizer wrapper around reference implementation with proper logging."""
 
     def __init__(
@@ -101,11 +101,10 @@ class CMAESwOptimizer(BaseOptimizer["CMAESLogData", CMAESConfig]):
                     best_fitness = fitness
                     best_solution = x.copy()
 
-                # Check budget
-                if self.evaluations >= self.config.budget:
-                    break
-
-            # Tell the optimizer about the solutions
+            # ``tell`` requires a full population; if the budget elapses mid
+            # population, the inner loop above always completes (a few extra
+            # evaluations vs corrupted internal state). The outer ``while``
+            # will exit on the next iteration.
             self._cma.tell(solutions)
 
             # Calculate statistics for logging
@@ -183,6 +182,20 @@ class CMAESwOptimizer(BaseOptimizer["CMAESLogData", CMAESConfig]):
         mean = self._cma._mean.copy()
         rank = min(C.shape[0], C.shape[1])
         return _decompose(C, mean, rank)
+
+    def get_eigendecomposition(
+        self,
+    ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+        """Return the cached eigendecomposition of the covariance matrix.
+
+        Returns ``(B, D)`` where ``B`` are the eigenvectors as columns and
+        ``D`` are the square roots of the eigenvalues, so that
+        ``C = B @ diag(D**2) @ B.T``. The reference implementation already
+        maintains this decomposition; reusing it avoids re-running an
+        ``eigh`` or ``inv`` call from the outside (e.g. for handoff).
+        """
+        B, D = self._cma._eigen_decomposition()
+        return B.copy(), D.copy()
 
     @property
     def sigma(self) -> float:

--- a/src/benchmarking/__init__.py
+++ b/src/benchmarking/__init__.py
@@ -1,0 +1,46 @@
+"""Benchmarking framework for fair, repeatable algorithm comparisons.
+
+Quick example:
+
+    from src.benchmarking import (
+        Benchmark, Problem, SingleAlgorithm, CMAESLBFGSBHandoff,
+    )
+
+    problem = Problem.from_benchmark("Rastrigin-10D", Rastrigin(10))
+    algorithms = [
+        SingleAlgorithm(name="CMA-ES",   color="#e74c3c", ...),
+        SingleAlgorithm(name="L-BFGS-B", color="#3498db", ...),
+        CMAESLBFGSBHandoff(name="CMA-ES + L-BFGS-B", color="#2ecc71", ...),
+    ]
+    Benchmark([problem], algorithms, seeds=range(25), output_dir="plots/").run()
+"""
+
+from src.benchmarking.algorithm_run import (
+    AlgorithmRun,
+    CMAESLBFGSBHandoff,
+    SingleAlgorithm,
+)
+from src.benchmarking.benchmark import Benchmark
+from src.benchmarking.persistence import (
+    load_traces_json,
+    save_runs_csv,
+    save_summary_csv,
+    save_traces_json,
+)
+from src.benchmarking.plotter import BenchmarkPlotter
+from src.benchmarking.problem import Problem
+from src.benchmarking.run_trace import RunTrace
+
+__all__ = [
+    "AlgorithmRun",
+    "Benchmark",
+    "BenchmarkPlotter",
+    "CMAESLBFGSBHandoff",
+    "Problem",
+    "RunTrace",
+    "SingleAlgorithm",
+    "load_traces_json",
+    "save_runs_csv",
+    "save_summary_csv",
+    "save_traces_json",
+]

--- a/src/benchmarking/aggregation.py
+++ b/src/benchmarking/aggregation.py
@@ -1,0 +1,97 @@
+"""Helpers to aggregate multiple RunTraces into a common evaluation grid.
+
+Each trace is a step function: best_fitness[i] holds from evaluations[i]
+up to evaluations[i+1]. To build per-evaluation summary statistics we
+sample each trace on a shared grid and return one matrix per algorithm.
+"""
+
+import warnings
+from typing import Iterable
+
+import numpy as np
+from numpy.typing import NDArray
+
+from src.benchmarking.run_trace import RunTrace
+
+
+def common_evaluation_grid(
+    traces: Iterable[RunTrace],
+    num_points: int = 200,
+    log_spaced: bool = True,
+    min_eval: int = 1,
+) -> NDArray[np.int64]:
+    """Build a shared evaluation grid spanning all traces.
+
+    Log-spaced grids give roughly uniform resolution on a log-x convergence
+    plot — useful since most progress happens early. Uses unique integers
+    so we don't waste samples on duplicate ticks for short runs.
+    """
+    max_eval = max(trace.final_evaluations for trace in traces)
+    if max_eval <= min_eval:
+        return np.array([min_eval], dtype=np.int64)
+
+    if log_spaced:
+        grid = np.geomspace(min_eval, max_eval, num=num_points)
+    else:
+        grid = np.linspace(min_eval, max_eval, num=num_points)
+
+    return np.unique(np.round(grid).astype(np.int64))
+
+
+def step_function_lookup(
+    evaluations: list[int],
+    best_fitness: list[float],
+    grid: NDArray[np.int64],
+) -> NDArray[np.float64]:
+    """Sample a (evaluations, best_fitness) trace on a grid.
+
+    Returns the best fitness reached at or before each grid point. Grid
+    points before the first logged evaluation are filled with ``+inf``
+    (no progress yet); points after the last logged evaluation are flat
+    at the trace's final value.
+    """
+    eval_array = np.asarray(evaluations, dtype=np.int64)
+    fitness_array = np.asarray(best_fitness, dtype=np.float64)
+
+    indices = np.searchsorted(eval_array, grid, side="right") - 1
+    out = np.empty_like(grid, dtype=np.float64)
+    out[indices < 0] = np.inf
+    valid = indices >= 0
+    out[valid] = fitness_array[indices[valid]]
+    return out
+
+
+def stack_traces_on_grid(
+    traces: Iterable[RunTrace],
+    grid: NDArray[np.int64],
+) -> NDArray[np.float64]:
+    """Stack multiple traces onto a shared grid. Returns shape (n_traces, n_grid)."""
+    return np.array(
+        [
+            step_function_lookup(trace.evaluations, trace.best_fitness, grid)
+            for trace in traces
+        ],
+        dtype=np.float64,
+    )
+
+
+def percentile_band(
+    matrix: NDArray[np.float64],
+    low_percentile: float = 25.0,
+    high_percentile: float = 75.0,
+) -> tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.float64]]:
+    """Return (median, low, high) per column, ignoring +inf entries when possible.
+
+    Early grid points may precede any algorithm's first logged evaluation —
+    those columns are all-NaN, which numpy warns about. The warnings are
+    benign (the corresponding grid point is just suppressed downstream), so
+    we silence them locally.
+    """
+    cleaned = np.where(np.isinf(matrix), np.nan, matrix)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=RuntimeWarning, message="All-NaN slice encountered")
+        warnings.filterwarnings("ignore", category=RuntimeWarning, message="All-NaN axis encountered")
+        median = np.nanmedian(cleaned, axis=0)
+        low = np.nanpercentile(cleaned, low_percentile, axis=0)
+        high = np.nanpercentile(cleaned, high_percentile, axis=0)
+    return median, low, high

--- a/src/benchmarking/algorithm_run.py
+++ b/src/benchmarking/algorithm_run.py
@@ -1,0 +1,243 @@
+"""Algorithm specifications for benchmarking.
+
+Each AlgorithmRun knows how to run itself on a Problem given an x0 and a
+seed, and reports a RunTrace. Concrete classes:
+
+- SingleAlgorithm: any registered AlgorithmFactory algorithm.
+- CMAESLBFGSBHandoff: warm-up CMA-ES, transform its covariance into B_0
+  for L-BFGS-B, then continue from the CMA-ES mean.
+"""
+
+from dataclasses import dataclass, field
+from typing import Callable, Protocol, runtime_checkable
+
+import numpy as np
+from numpy.typing import NDArray
+
+from src.algorithms.choices import AlgorithmChoice
+from src.algorithms.cmaes.config import CMAESConfig
+from src.algorithms.lbfgsb.config import LBFGSBConfig
+from src.benchmarking.problem import Problem
+from src.benchmarking.run_trace import RunTrace
+from src.core.algorithm_factory import AlgorithmFactory
+from src.core.config_base import BaseConfig
+
+
+_EIGENVALUE_FLOOR = 1e-30
+
+
+@runtime_checkable
+class AlgorithmRun(Protocol):
+    """An algorithm spec: name, color, and a runner."""
+
+    name: str
+    color: str
+
+    def run(
+        self,
+        problem: Problem,
+        x0: NDArray[np.float64],
+        seed: int,
+    ) -> RunTrace: ...
+
+
+def _enable_diagnostics(config: BaseConfig) -> None:
+    """Make sure best-fitness logging is on (it usually is by default)."""
+    if hasattr(config, "diag_bestVal"):
+        config.diag_bestVal = True
+
+
+@dataclass
+class SingleAlgorithm:
+    """A single optimizer registered in the AlgorithmFactory."""
+
+    name: str
+    color: str
+    algorithm: AlgorithmChoice
+    config_factory: Callable[[int], BaseConfig]
+    """Builds a fresh config given the problem's dimensions."""
+
+    extra_diagnostics: tuple[str, ...] = ()
+    """Names of additional diag_* flags to enable on the config."""
+
+    def run(
+        self,
+        problem: Problem,
+        x0: NDArray[np.float64],
+        seed: int,
+    ) -> RunTrace:
+        config = self.config_factory(problem.dimensions)
+        _enable_diagnostics(config)
+        for flag in self.extra_diagnostics:
+            if hasattr(config, flag):
+                setattr(config, flag, True)
+
+        kwargs: dict = {}
+        if problem.gradient is not None and self.algorithm == AlgorithmChoice.LBFGSB:
+            kwargs["gradient_fn"] = problem.gradient
+
+        optimizer = AlgorithmFactory.create_optimizer(
+            self.algorithm,
+            problem.function,
+            x0,
+            config,
+            lower_bounds=problem.lower_bound,
+            upper_bounds=problem.upper_bound,
+            seed=seed,
+            **kwargs,
+        )
+        result = optimizer.optimize()
+
+        return RunTrace(
+            algorithm=self.name,
+            problem=problem.name,
+            seed=seed,
+            evaluations=list(result.diagnostic.evaluations),
+            best_fitness=list(result.diagnostic.best_fitness),
+            final_evaluations=result.evaluations,
+            final_fitness=float(result.best_fitness),
+        )
+
+
+@dataclass
+class CMAESLBFGSBHandoff:
+    """CMA-ES warm-up followed by L-BFGS-B with a covariance-derived B_0.
+
+    Steps:
+
+    1. Run CMA-ES on the problem until ``cmaes_config.budget`` evaluations
+       are consumed. Same seed and same x0 as a standalone CMA-ES run will
+       produce an identical CMA-ES prefix in the convergence trace.
+    2. Read the cached eigendecomposition (B, D) from CMA-ES.
+    3. Compose the initial Hessian for L-BFGS-B according to ``transform``:
+       - "inverse" (default) -> C^{-1}
+       - "sigma_inverse"      -> (sigma^2 C)^{-1}
+       - "identity"           -> no Hessian info (L-BFGS-B default B_0 = I);
+                                 isolates the value of just sharing the
+                                 starting point with CMA-ES.
+    4. Run L-BFGS-B from the CMA-ES mean with that B_0 and a separate
+       budget.
+
+    The convergence trace is the concatenation of the two phases. The
+    L-BFGS-B segment is clamped so it never reports a fitness worse than
+    the CMA-ES handoff value (handles cases where L-BFGS-B's first step
+    happens to land slightly worse than the warm-up's best).
+    """
+
+    name: str
+    color: str
+    cmaes_config_factory: Callable[[int], CMAESConfig]
+    lbfgsb_config_factory: Callable[[int], LBFGSBConfig]
+    transform: str = "inverse"
+
+    cmaes_extra_diagnostics: tuple[str, ...] = ("diag_eigen",)
+    lbfgsb_extra_diagnostics: tuple[str, ...] = ()
+
+    def _initial_hessian_from_cmaes(
+        self,
+        eigenvectors: NDArray[np.float64],
+        eigenvalues_sqrt: NDArray[np.float64],
+        sigma: float,
+    ) -> NDArray[np.float64] | None:
+        if self.transform == "identity":
+            return None
+
+        eigenvalues = np.maximum(eigenvalues_sqrt**2, _EIGENVALUE_FLOOR)
+
+        # Floored 1/eigenvalues can be huge (up to 1e30); the matmul values
+        # are still valid but numpy raises spurious divide/overflow warnings
+        # on the intermediates.
+        with np.errstate(over="ignore", divide="ignore", invalid="ignore"):
+            if self.transform == "inverse":
+                return (eigenvectors * (1.0 / eigenvalues)) @ eigenvectors.T
+            if self.transform == "sigma_inverse":
+                inverse = (eigenvectors * (1.0 / eigenvalues)) @ eigenvectors.T
+                return inverse / (sigma * sigma)
+
+        raise ValueError(
+            f"Unknown handoff transform: {self.transform!r}. "
+            f"Use 'inverse', 'sigma_inverse', or 'identity'."
+        )
+
+    def run(
+        self,
+        problem: Problem,
+        x0: NDArray[np.float64],
+        seed: int,
+    ) -> RunTrace:
+        # Phase 1: CMA-ES warm-up.
+        cmaes_config = self.cmaes_config_factory(problem.dimensions)
+        _enable_diagnostics(cmaes_config)
+        for flag in self.cmaes_extra_diagnostics:
+            if hasattr(cmaes_config, flag):
+                setattr(cmaes_config, flag, True)
+
+        cmaes_optimizer = AlgorithmFactory.create_optimizer(
+            AlgorithmChoice.CMAES,
+            problem.function,
+            x0,
+            cmaes_config,
+            lower_bounds=problem.lower_bound,
+            upper_bounds=problem.upper_bound,
+            seed=seed,
+        )
+        cmaes_result = cmaes_optimizer.optimize()
+        warmup_evals = cmaes_result.evaluations
+        warmup_iters = len(cmaes_result.diagnostic.iteration)
+
+        eigenvectors, eigenvalues_sqrt = cmaes_optimizer.get_eigendecomposition()
+        sigma = cmaes_optimizer.sigma
+        starting_point = cmaes_optimizer.mean
+        cmaes_best = float(cmaes_result.best_fitness)
+
+        # Phase 2: L-BFGS-B with a covariance-derived B_0.
+        initial_hessian = self._initial_hessian_from_cmaes(
+            eigenvectors, eigenvalues_sqrt, sigma
+        )
+
+        lbfgsb_config = self.lbfgsb_config_factory(problem.dimensions)
+        lbfgsb_config.initial_hessian = initial_hessian
+        _enable_diagnostics(lbfgsb_config)
+        for flag in self.lbfgsb_extra_diagnostics:
+            if hasattr(lbfgsb_config, flag):
+                setattr(lbfgsb_config, flag, True)
+
+        kwargs: dict = {}
+        if problem.gradient is not None:
+            kwargs["gradient_fn"] = problem.gradient
+
+        lbfgsb_optimizer = AlgorithmFactory.create_optimizer(
+            AlgorithmChoice.LBFGSB,
+            problem.function,
+            starting_point,
+            lbfgsb_config,
+            lower_bounds=problem.lower_bound,
+            upper_bounds=problem.upper_bound,
+            **kwargs,
+        )
+        lbfgsb_result = lbfgsb_optimizer.optimize()
+
+        # Concatenate traces. Offset L-BFGS-B evals so the trace is continuous,
+        # and clamp its fitness to never exceed the handoff value (the L-BFGS-B
+        # logger reports its own best, which starts at f(x0_lbfgsb), not f_best).
+        cmaes_evals = list(cmaes_result.diagnostic.evaluations)
+        cmaes_fits = list(cmaes_result.diagnostic.best_fitness)
+        lbfgsb_evals = [
+            evaluation + warmup_evals
+            for evaluation in lbfgsb_result.diagnostic.evaluations
+        ]
+        lbfgsb_fits = [min(value, cmaes_best) for value in lbfgsb_result.diagnostic.best_fitness]
+
+        final_fitness = min(cmaes_best, float(lbfgsb_result.best_fitness))
+
+        return RunTrace(
+            algorithm=self.name,
+            problem=problem.name,
+            seed=seed,
+            evaluations=cmaes_evals + lbfgsb_evals,
+            best_fitness=cmaes_fits + lbfgsb_fits,
+            final_evaluations=warmup_evals + lbfgsb_result.evaluations,
+            final_fitness=final_fitness,
+            handoff_eval=warmup_evals,
+            handoff_iter=warmup_iters,
+        )

--- a/src/benchmarking/benchmark.py
+++ b/src/benchmarking/benchmark.py
@@ -1,0 +1,257 @@
+"""Benchmark orchestrator.
+
+Given a list of problems, a list of algorithm specs, and a list of seeds,
+runs every (problem, algorithm, seed) combination and stores the
+RunTraces. Produces convergence plots (median + IQR across seeds) and
+final-fitness distribution summaries.
+
+Set ``num_workers > 1`` to parallelize across (problem, algorithm, seed)
+triples via joblib (which uses cloudpickle and so handles lambdas).
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+import time
+from typing import Optional
+
+from joblib import Parallel, delayed
+
+from src.benchmarking.algorithm_run import AlgorithmRun
+from src.benchmarking.persistence import (
+    save_runs_csv,
+    save_summary_csv,
+    save_traces_json,
+)
+from src.benchmarking.problem import Problem
+from src.benchmarking.run_trace import RunTrace
+
+
+def _execute_one(
+    algorithm: AlgorithmRun,
+    problem: Problem,
+    x0,
+    seed: int,
+) -> tuple[str, str, RunTrace]:
+    """Worker entry point; returned tuple is keyed for re-assembly."""
+    trace = algorithm.run(problem, x0, seed)
+    return problem.name, algorithm.name, trace
+
+
+@dataclass
+class Benchmark:
+    """Run a grid of (problem x algorithm x seed) optimization runs."""
+
+    problems: list[Problem]
+    algorithms: list[AlgorithmRun]
+    seeds: list[int]
+    output_dir: Path
+
+    num_workers: int = 1
+    """Process count. 1 (default) keeps it serial; >1 uses joblib's loky backend."""
+
+    save_artifacts: bool = True
+    """If True, dump traces.json + runs.csv + summary.csv into ``output_dir`` after run()."""
+
+    traces: dict[tuple[str, str], list[RunTrace]] = field(default_factory=dict)
+    """Keyed by (problem.name, algorithm.name) -> list of traces (one per seed)."""
+
+    def __post_init__(self) -> None:
+        self.output_dir = Path(self.output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+    def _build_jobs(self) -> list[tuple[AlgorithmRun, Problem, "np.ndarray", int]]:
+        jobs = []
+        for problem in self.problems:
+            for seed in self.seeds:
+                x0 = problem.starting_point(seed)
+                for algorithm in self.algorithms:
+                    jobs.append((algorithm, problem, x0, seed))
+        return jobs
+
+    def run(self, verbose: bool = True) -> dict[tuple[str, str], list[RunTrace]]:
+        """Execute all runs and store traces. Returns the trace dictionary."""
+        jobs = self._build_jobs()
+        total_runs = len(jobs)
+        start = time.time()
+
+        if verbose:
+            mode = (
+                "serial"
+                if self.num_workers <= 1
+                else f"parallel (n_workers={self.num_workers})"
+            )
+            print(f"Running {total_runs} jobs in {mode} mode.")
+
+        if self.num_workers <= 1:
+            results = self._run_serial(jobs, verbose, start)
+        else:
+            results = self._run_parallel(jobs, verbose, start)
+
+        for problem_name, algorithm_name, trace in results:
+            key = (problem_name, algorithm_name)
+            self.traces.setdefault(key, []).append(trace)
+
+        # Sort each (problem, algorithm) bucket by seed so the trace order
+        # is stable regardless of parallel completion order. Plotters and
+        # summary statistics don't depend on order, but persistence /
+        # diff-against-reference workflows do.
+        for traces in self.traces.values():
+            traces.sort(key=lambda trace: trace.seed)
+
+        if verbose:
+            print(f"\nAll runs done in {time.time() - start:.1f}s.")
+
+        if self.save_artifacts:
+            self._save_artifacts(verbose=verbose)
+
+        return self.traces
+
+    def _run_serial(
+        self,
+        jobs: list,
+        verbose: bool,
+        start: float,
+    ) -> list[tuple[str, str, RunTrace]]:
+        results: list[tuple[str, str, RunTrace]] = []
+        prev_problem: Optional[str] = None
+        prev_seed: Optional[int] = None
+        for idx, (algorithm, problem, x0, seed) in enumerate(jobs, start=1):
+            if verbose and problem.name != prev_problem:
+                print(f"\n{'=' * 70}")
+                print(
+                    f"Problem: {problem.name} "
+                    f"(d={problem.dimensions}, "
+                    f"bounds=[{problem.lower_bound}, {problem.upper_bound}])"
+                )
+                print(f"{'=' * 70}")
+                prev_problem = problem.name
+                prev_seed = None
+            if verbose and seed != prev_seed:
+                f_x0 = float(problem.function(x0))
+                print(f"\n  seed={seed} | f(x0) = {f_x0:.4e}")
+                prev_seed = seed
+
+            trace = algorithm.run(problem, x0, seed)
+            results.append((problem.name, algorithm.name, trace))
+
+            if verbose:
+                self._print_progress(idx, len(jobs), algorithm.name, trace, start)
+        return results
+
+    def _run_parallel(
+        self,
+        jobs: list,
+        verbose: bool,
+        start: float,
+    ) -> list[tuple[str, str, RunTrace]]:
+        # joblib's loky backend ships closures via cloudpickle, so lambdas in
+        # config_factory work transparently.
+        completed = 0
+        total = len(jobs)
+        results: list[tuple[str, str, RunTrace]] = []
+
+        def callback(result: tuple[str, str, RunTrace]) -> tuple[str, str, RunTrace]:
+            nonlocal completed
+            completed += 1
+            if verbose:
+                _, algorithm_name, trace = result
+                self._print_progress(completed, total, algorithm_name, trace, start)
+            return result
+
+        raw = Parallel(n_jobs=self.num_workers, backend="loky")(
+            delayed(_execute_one)(algorithm, problem, x0, seed)
+            for algorithm, problem, x0, seed in jobs
+        )
+        for result in raw:
+            results.append(callback(result))
+        return results
+
+    def _print_progress(
+        self,
+        idx: int,
+        total: int,
+        algorithm_name: str,
+        trace: RunTrace,
+        start: float,
+    ) -> None:
+        handoff_str = (
+            f" handoff@{trace.handoff_eval}"
+            if trace.handoff_eval is not None
+            else ""
+        )
+        elapsed = time.time() - start
+        print(
+            f"    [{idx:>3d}/{total}] "
+            f"{algorithm_name:32s} "
+            f"problem={trace.problem:12s} "
+            f"seed={trace.seed:>3d}  "
+            f"f={trace.final_fitness:.4e}  "
+            f"evals={trace.final_evaluations:>6d}"
+            f"{handoff_str}  "
+            f"({elapsed:.1f}s)"
+        )
+
+    def _save_artifacts(self, verbose: bool) -> None:
+        traces_path = save_traces_json(self.traces, self.output_dir / "traces.json")
+        runs_path = save_runs_csv(self.traces, self.output_dir / "runs.csv")
+        summary_path = save_summary_csv(
+            self.summary_table(), self.output_dir / "summary.csv"
+        )
+        if verbose:
+            print(f"\nArtifacts written:")
+            print(f"  - {traces_path}")
+            print(f"  - {runs_path}")
+            print(f"  - {summary_path}")
+
+    def traces_for(self, problem_name: str, algorithm_name: str) -> list[RunTrace]:
+        return self.traces.get((problem_name, algorithm_name), [])
+
+    def summary_table(self) -> list[dict]:
+        """One row per (problem, algorithm) with aggregate statistics."""
+        import numpy as np
+
+        rows: list[dict] = []
+        for problem in self.problems:
+            for algorithm in self.algorithms:
+                traces = self.traces_for(problem.name, algorithm.name)
+                if not traces:
+                    continue
+                final_fitnesses = np.array([t.final_fitness for t in traces])
+                final_evaluations = np.array([t.final_evaluations for t in traces])
+                rows.append(
+                    {
+                        "problem": problem.name,
+                        "algorithm": algorithm.name,
+                        "n_runs": len(traces),
+                        "median_fitness": float(np.median(final_fitnesses)),
+                        "mean_fitness": float(np.mean(final_fitnesses)),
+                        "best_fitness": float(np.min(final_fitnesses)),
+                        "worst_fitness": float(np.max(final_fitnesses)),
+                        "median_evaluations": float(np.median(final_evaluations)),
+                    }
+                )
+        return rows
+
+    def print_summary(self) -> None:
+        rows = self.summary_table()
+        if not rows:
+            print("No runs to summarise.")
+            return
+
+        header = (
+            f"{'Problem':<15s} {'Algorithm':<32s} "
+            f"{'n':>3s} {'median f':>12s} {'best f':>12s} "
+            f"{'worst f':>12s} {'median evals':>13s}"
+        )
+        print()
+        print(header)
+        print("-" * len(header))
+        for row in rows:
+            print(
+                f"{row['problem']:<15s} {row['algorithm']:<32s} "
+                f"{row['n_runs']:>3d} "
+                f"{row['median_fitness']:>12.4e} "
+                f"{row['best_fitness']:>12.4e} "
+                f"{row['worst_fitness']:>12.4e} "
+                f"{int(row['median_evaluations']):>13d}"
+            )

--- a/src/benchmarking/persistence.py
+++ b/src/benchmarking/persistence.py
@@ -1,0 +1,119 @@
+"""Save and load RunTraces.
+
+After a Benchmark.run() the traces live in memory only. Persisting them
+to disk lets a re-plot or post-hoc statistical analysis skip re-running
+the optimizers.
+
+- ``traces.json``  : structured dump of every trace (lists in, lists out).
+- ``summary.csv``  : one row per (problem, algorithm) with median/best/etc.
+- ``runs.csv``     : one row per run with final fitness, eval count,
+                     handoff eval, seed. Easier for spreadsheets.
+"""
+
+import csv
+import json
+from pathlib import Path
+from typing import Iterable, Union
+
+from src.benchmarking.run_trace import RunTrace
+
+
+def _trace_to_dict(trace: RunTrace) -> dict:
+    return {
+        "algorithm": trace.algorithm,
+        "problem": trace.problem,
+        "seed": trace.seed,
+        "evaluations": list(trace.evaluations),
+        "best_fitness": list(trace.best_fitness),
+        "final_evaluations": trace.final_evaluations,
+        "final_fitness": trace.final_fitness,
+        "handoff_eval": trace.handoff_eval,
+        "handoff_iter": trace.handoff_iter,
+    }
+
+
+def _trace_from_dict(payload: dict) -> RunTrace:
+    return RunTrace(
+        algorithm=payload["algorithm"],
+        problem=payload["problem"],
+        seed=int(payload["seed"]),
+        evaluations=[int(x) for x in payload["evaluations"]],
+        best_fitness=[float(x) for x in payload["best_fitness"]],
+        final_evaluations=int(payload["final_evaluations"]),
+        final_fitness=float(payload["final_fitness"]),
+        handoff_eval=(
+            int(payload["handoff_eval"]) if payload["handoff_eval"] is not None else None
+        ),
+        handoff_iter=(
+            int(payload["handoff_iter"]) if payload.get("handoff_iter") is not None else None
+        ),
+    )
+
+
+def save_traces_json(
+    traces: dict[tuple[str, str], list[RunTrace]],
+    path: Union[str, Path],
+) -> Path:
+    """Write the full trace dictionary as a single JSON file."""
+    path = Path(path)
+    payload = {
+        "runs": [
+            _trace_to_dict(trace)
+            for run_list in traces.values()
+            for trace in run_list
+        ],
+    }
+    path.write_text(json.dumps(payload, indent=2))
+    return path
+
+
+def load_traces_json(path: Union[str, Path]) -> dict[tuple[str, str], list[RunTrace]]:
+    """Reconstruct the trace dictionary from a previously saved JSON file."""
+    payload = json.loads(Path(path).read_text())
+    traces: dict[tuple[str, str], list[RunTrace]] = {}
+    for run in payload["runs"]:
+        trace = _trace_from_dict(run)
+        traces.setdefault((trace.problem, trace.algorithm), []).append(trace)
+    return traces
+
+
+def save_runs_csv(
+    traces: dict[tuple[str, str], list[RunTrace]],
+    path: Union[str, Path],
+) -> Path:
+    """Write one CSV row per run (good for spreadsheet inspection)."""
+    path = Path(path)
+    rows = [
+        {
+            "problem": trace.problem,
+            "algorithm": trace.algorithm,
+            "seed": trace.seed,
+            "final_fitness": trace.final_fitness,
+            "final_evaluations": trace.final_evaluations,
+            "handoff_eval": "" if trace.handoff_eval is None else trace.handoff_eval,
+        }
+        for run_list in traces.values()
+        for trace in run_list
+    ]
+    with path.open("w", newline="") as fh:
+        if rows:
+            writer = csv.DictWriter(fh, fieldnames=list(rows[0].keys()))
+            writer.writeheader()
+            writer.writerows(rows)
+        else:
+            fh.write("")
+    return path
+
+
+def save_summary_csv(rows: Iterable[dict], path: Union[str, Path]) -> Path:
+    """Write the aggregate summary table (one row per problem x algorithm)."""
+    path = Path(path)
+    rows = list(rows)
+    with path.open("w", newline="") as fh:
+        if rows:
+            writer = csv.DictWriter(fh, fieldnames=list(rows[0].keys()))
+            writer.writeheader()
+            writer.writerows(rows)
+        else:
+            fh.write("")
+    return path

--- a/src/benchmarking/plotter.py
+++ b/src/benchmarking/plotter.py
@@ -1,0 +1,242 @@
+"""Plotting helpers for the benchmarking framework.
+
+Produces convergence plots with median + IQR bands across seeds, plus
+final-fitness distribution boxplots. Designed to make the experiment's
+key claim — "this combo beats either alone" — readable at a glance.
+"""
+
+from pathlib import Path
+from typing import Optional, Union
+
+import matplotlib.pyplot as plt
+import numpy as np
+from numpy.typing import NDArray
+
+from src.benchmarking.aggregation import (
+    common_evaluation_grid,
+    percentile_band,
+    stack_traces_on_grid,
+)
+from src.benchmarking.algorithm_run import AlgorithmRun
+from src.benchmarking.problem import Problem
+from src.benchmarking.run_trace import RunTrace
+
+
+class BenchmarkPlotter:
+    """Plotter for results coming out of a Benchmark run."""
+
+    def __init__(
+        self,
+        problems: list[Problem],
+        algorithms: list[AlgorithmRun],
+        traces: dict[tuple[str, str], list[RunTrace]],
+        output_dir: Union[str, Path],
+        floor: float = 1e-12,
+    ):
+        self.problems = problems
+        self.algorithms = algorithms
+        self.traces = traces
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.floor = floor
+
+    def _algorithm_color(self, algorithm: AlgorithmRun) -> str:
+        return algorithm.color
+
+    def plot_convergence_grid(
+        self,
+        save_path: Optional[Union[str, Path]] = None,
+        title: Optional[str] = None,
+        num_grid_points: int = 200,
+        show_iqr: bool = True,
+        linewidth: float = 2.5,
+        iqr_alpha: float = 0.15,
+        legend_fontsize: int = 10,
+        figsize_per_panel: tuple[float, float] = (8.5, 6.0),
+        annotate_handoff: bool = True,
+    ) -> plt.Figure:
+        """One subplot per problem. Median + IQR across seeds for each algorithm.
+
+        Floors fitness values at ``self.floor`` before log-scaling so the
+        y-axis remains finite for runs that converge essentially to zero.
+        """
+        num_problems = len(self.problems)
+        cols = min(num_problems, 2)
+        rows = (num_problems + cols - 1) // cols
+        fig, axes = plt.subplots(
+            rows, cols,
+            figsize=(figsize_per_panel[0] * cols, figsize_per_panel[1] * rows),
+        )
+        axes = np.atleast_1d(axes).flatten()
+
+        for problem_idx, problem in enumerate(self.problems):
+            ax = axes[problem_idx]
+
+            # Build a shared grid spanning all algorithm traces for this problem.
+            all_traces: list[RunTrace] = []
+            for algorithm in self.algorithms:
+                all_traces.extend(self.traces.get((problem.name, algorithm.name), []))
+            if not all_traces:
+                ax.set_visible(False)
+                continue
+            grid = common_evaluation_grid(all_traces, num_points=num_grid_points)
+
+            handoff_markers: dict[int, Optional[int]] = {}
+            """eval at handoff -> iter at handoff (if known) for this panel."""
+
+            for algorithm in self.algorithms:
+                traces = self.traces.get((problem.name, algorithm.name), [])
+                if not traces:
+                    continue
+
+                matrix = stack_traces_on_grid(traces, grid)
+                matrix = np.maximum(matrix, self.floor)
+                median, low, high = percentile_band(matrix)
+
+                color = self._algorithm_color(algorithm)
+                final_median = float(np.median([t.final_fitness for t in traces]))
+                ax.semilogy(
+                    grid,
+                    median,
+                    color=color,
+                    linewidth=linewidth,
+                    label=f"{algorithm.name}  (median = {final_median:.2e})",
+                )
+                if show_iqr and len(traces) > 1:
+                    ax.fill_between(grid, low, high, color=color, alpha=iqr_alpha)
+
+                handoff_traces = [t for t in traces if t.handoff_eval is not None]
+                if handoff_traces:
+                    median_eval = int(np.median([t.handoff_eval for t in handoff_traces]))
+                    iters = [t.handoff_iter for t in handoff_traces if t.handoff_iter is not None]
+                    median_iter = int(np.median(iters)) if iters else None
+                    handoff_markers[median_eval] = median_iter
+
+            for handoff_eval, handoff_iter in handoff_markers.items():
+                ax.axvline(
+                    handoff_eval,
+                    color="black",
+                    linestyle="--",
+                    linewidth=1.2,
+                    alpha=0.45,
+                )
+                if annotate_handoff:
+                    if handoff_iter is not None:
+                        label = f"  handoff @ {handoff_iter} gen ({handoff_eval} evals)"
+                    else:
+                        label = f"  handoff @ {handoff_eval} evals"
+                    ymax = ax.get_ylim()[1]
+                    ax.text(
+                        handoff_eval, ymax,
+                        label,
+                        rotation=90, va="top", ha="left",
+                        fontsize=8, color="gray", alpha=0.7,
+                    )
+
+            ax.set_xlabel("Function Evaluations", fontsize=12)
+            ax.set_ylabel("Best Fitness (log)", fontsize=12)
+            ax.set_title(
+                f"{problem.name}  (d={problem.dimensions}, "
+                f"n_seeds={len(traces)})",
+                fontsize=13,
+            )
+            ax.grid(True, alpha=0.25, which="both")
+            ax.legend(fontsize=legend_fontsize, loc="best", framealpha=0.9)
+            ax.tick_params(axis="both", labelsize=10)
+
+        for idx in range(num_problems, len(axes)):
+            axes[idx].set_visible(False)
+
+        if title:
+            fig.suptitle(title, fontsize=14, y=1.01)
+        plt.tight_layout()
+
+        if save_path:
+            fig.savefig(save_path, dpi=110, bbox_inches="tight")
+        return fig
+
+    def plot_final_fitness_boxplot(
+        self,
+        save_path: Optional[Union[str, Path]] = None,
+        title: Optional[str] = None,
+    ) -> plt.Figure:
+        """Boxplot of final fitness per algorithm, one panel per problem.
+
+        Runs that reached zero or sub-floor fitness are dropped from the
+        boxplot (a log y-axis can't display them honestly). The number of
+        such runs per algorithm is annotated above the box as ``n=*/N``
+        where the star is the surviving count.
+        """
+        num_problems = len(self.problems)
+        cols = min(num_problems, 2)
+        rows = (num_problems + cols - 1) // cols
+        fig, axes = plt.subplots(rows, cols, figsize=(7 * cols, 4.5 * rows))
+        axes = np.atleast_1d(axes).flatten()
+
+        for problem_idx, problem in enumerate(self.problems):
+            ax = axes[problem_idx]
+
+            data: list[NDArray[np.float64]] = []
+            labels: list[str] = []
+            colors: list[str] = []
+            dropped_counts: list[tuple[int, int]] = []
+            for algorithm in self.algorithms:
+                traces = self.traces.get((problem.name, algorithm.name), [])
+                if not traces:
+                    continue
+                raw = np.array([t.final_fitness for t in traces])
+                surviving = raw[raw > self.floor]
+                if surviving.size == 0:
+                    # Everything reached zero; nothing to plot. Skip but
+                    # still record so the label/count appears.
+                    data.append(np.array([self.floor]))
+                else:
+                    data.append(surviving)
+                labels.append(algorithm.name)
+                colors.append(self._algorithm_color(algorithm))
+                dropped_counts.append((int(surviving.size), int(raw.size)))
+
+            if not data:
+                ax.set_visible(False)
+                continue
+
+            box = ax.boxplot(
+                data,
+                labels=labels,
+                patch_artist=True,
+                showmeans=True,
+                meanline=True,
+            )
+            for patch, color in zip(box["boxes"], colors):
+                patch.set_facecolor(color)
+                patch.set_alpha(0.5)
+
+            ax.set_yscale("log")
+            ax.set_ylabel("Final Best Fitness (log)", fontsize=11)
+            ax.set_title(
+                f"{problem.name} (d={problem.dimensions})",
+                fontsize=12,
+            )
+            ax.grid(True, alpha=0.3, axis="y")
+            ax.tick_params(axis="x", labelrotation=15)
+
+            for tick_idx, (kept, total) in enumerate(dropped_counts, start=1):
+                if kept < total:
+                    ax.annotate(
+                        f"n={kept}/{total}",
+                        xy=(tick_idx, 0.98),
+                        xycoords=("data", "axes fraction"),
+                        ha="center", va="top",
+                        fontsize=8, color="dimgray",
+                    )
+
+        for idx in range(num_problems, len(axes)):
+            axes[idx].set_visible(False)
+
+        if title:
+            fig.suptitle(title, fontsize=14, y=1.01)
+        plt.tight_layout()
+
+        if save_path:
+            fig.savefig(save_path, dpi=110, bbox_inches="tight")
+        return fig

--- a/src/benchmarking/problem.py
+++ b/src/benchmarking/problem.py
@@ -1,0 +1,64 @@
+"""A test problem: function, dimensions, bounds, and a deterministic
+starting-point generator keyed by seed.
+
+Two algorithms run with the same seed start from the same x0 — that's the
+property the framework relies on for fair side-by-side comparison.
+"""
+
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+import numpy as np
+from numpy.typing import NDArray
+
+from src.utils.benchmark_functions import BenchmarkFunction
+
+
+@dataclass
+class Problem:
+    """Test problem specification."""
+
+    name: str
+    """Short name used in plots and tables."""
+
+    function: Callable[[NDArray[np.float64]], float]
+    """Objective; usually a BenchmarkFunction subclass."""
+
+    dimensions: int
+
+    lower_bound: float
+    upper_bound: float
+
+    gradient: Optional[Callable[[NDArray[np.float64]], NDArray[np.float64]]] = None
+    """Analytical gradient. If None, L-BFGS-B uses finite differences."""
+
+    @classmethod
+    def from_benchmark(
+        cls,
+        name: str,
+        function: BenchmarkFunction,
+        lower_bound: Optional[float] = None,
+        upper_bound: Optional[float] = None,
+    ) -> "Problem":
+        """Build a Problem from a BenchmarkFunction.
+
+        Picks up the function's bounds and ``gradient`` attribute (if any)
+        unless explicit values are passed.
+        """
+        lb_array, ub_array = function.bounds
+        return cls(
+            name=name,
+            function=function,
+            dimensions=function.dimensions,
+            lower_bound=float(lb_array[0]) if lower_bound is None else lower_bound,
+            upper_bound=float(ub_array[0]) if upper_bound is None else upper_bound,
+            gradient=getattr(function, "gradient", None),
+        )
+
+    def starting_point(self, seed: int) -> NDArray[np.float64]:
+        """Deterministic uniform starting point inside the bounds.
+
+        Same seed => same x0, regardless of which algorithm consumes it.
+        """
+        rng = np.random.default_rng(seed)
+        return rng.uniform(self.lower_bound, self.upper_bound, size=self.dimensions)

--- a/src/benchmarking/run_trace.py
+++ b/src/benchmarking/run_trace.py
@@ -1,0 +1,47 @@
+"""Result of a single (problem, algorithm, seed) run.
+
+Stores the convergence trace as two parallel lists. ``evaluations`` is the
+cumulative function-evaluation count at each logged step; ``best_fitness``
+is the best objective value seen so far. Both are monotone (non-decreasing
+and non-increasing respectively).
+
+For chained algorithms (e.g. CMA-ES -> L-BFGS-B handoff) the lists are
+concatenated and ``handoff_eval`` marks the boundary.
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class RunTrace:
+    """A single run's convergence record."""
+
+    algorithm: str
+    """Algorithm name (matches the AlgorithmRun that produced this)."""
+
+    problem: str
+    """Problem name."""
+
+    seed: int
+
+    evaluations: list[int] = field(default_factory=list)
+    """Cumulative evaluations at each logged point."""
+
+    best_fitness: list[float] = field(default_factory=list)
+    """Best fitness so far at each logged point."""
+
+    final_evaluations: int = 0
+    """Total evaluations consumed by the run."""
+
+    final_fitness: float = float("inf")
+    """Final best fitness."""
+
+    handoff_eval: Optional[int] = None
+    """Evaluation count at which an algorithm handoff occurred, if any."""
+
+    handoff_iter: Optional[int] = None
+    """CMA-ES generation count at which the handoff occurred. Same event as
+    ``handoff_eval`` but expressed in iterations of the warmup algorithm.
+    Useful when plots want to annotate handoffs in a population-size-agnostic
+    way."""

--- a/src/utils/benchmark_functions.py
+++ b/src/utils/benchmark_functions.py
@@ -124,9 +124,65 @@ class Rastrigin(BenchmarkFunction):
     def __call__(self, x: NDArray[np.float64]) -> float:
         return 10 * self.dimensions + np.sum(x**2 - 10 * np.cos(2 * np.pi * x))
 
+    def gradient(self, x: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Analytical gradient: 2*x_i + 20*pi*sin(2*pi*x_i)."""
+        return 2.0 * x + 20.0 * np.pi * np.sin(2.0 * np.pi * x)
+
     @property
     def bounds(self) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
         return -5.12 * np.ones(self.dimensions), 5.12 * np.ones(self.dimensions)
+
+    @property
+    def global_minimum(self) -> tuple[NDArray[np.float64], float]:
+        return np.zeros(self.dimensions), 0.0
+
+
+class Griewank(BenchmarkFunction):
+    """
+    Griewank function.
+    f(x) = 1 + sum(x_i^2 / 4000) - prod(cos(x_i / sqrt(i)))
+    Global minimum: f(0, 0, ..., 0) = 0
+
+    Multimodal with many local minima but a soft global trend that points
+    towards the origin — well suited for testing whether a hybrid
+    CMA-ES -> L-BFGS-B handoff can locate a basin and then descend it.
+    """
+
+    def __call__(self, x: NDArray[np.float64]) -> float:
+        indices = np.arange(1, len(x) + 1)
+        sum_term = np.sum(x**2) / 4000.0
+        prod_term = np.prod(np.cos(x / np.sqrt(indices)))
+        return float(1.0 + sum_term - prod_term)
+
+    def gradient(self, x: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Analytical gradient.
+
+        df/dx_i = x_i / 2000 + sin(x_i/sqrt(i)) / sqrt(i) * prod_{j != i} cos(x_j/sqrt(j))
+        """
+        indices = np.arange(1, len(x) + 1)
+        sqrt_indices = np.sqrt(indices)
+        cosines = np.cos(x / sqrt_indices)
+        sines = np.sin(x / sqrt_indices)
+
+        # prod_{j != i} cos(...) = total_product / cos(...) when cos is non-zero;
+        # when a cosine is exactly zero the leave-one-out product collapses,
+        # so handle it directly.
+        zeros = cosines == 0.0
+        if np.any(zeros):
+            leave_one_out = np.empty_like(cosines)
+            for i in range(len(cosines)):
+                mask = np.ones_like(cosines, dtype=bool)
+                mask[i] = False
+                leave_one_out[i] = np.prod(cosines[mask])
+        else:
+            total_product = np.prod(cosines)
+            leave_one_out = total_product / cosines
+
+        return x / 2000.0 + sines / sqrt_indices * leave_one_out
+
+    @property
+    def bounds(self) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+        return -600.0 * np.ones(self.dimensions), 600.0 * np.ones(self.dimensions)
 
     @property
     def global_minimum(self) -> tuple[NDArray[np.float64], float]:
@@ -144,6 +200,17 @@ class Ackley(BenchmarkFunction):
         term1 = -20.0 * np.exp(-0.2 * np.sqrt(np.mean(x**2)))
         term2 = -np.exp(np.mean(np.cos(2 * np.pi * x)))
         return term1 + term2 + 20.0 + np.e
+
+    def gradient(self, x: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Analytical gradient. Returns zero at the (degenerate) origin."""
+        n = len(x)
+        rms = np.sqrt(np.mean(x**2))
+        if rms == 0.0:
+            return np.zeros_like(x)
+        term1 = (4.0 / n) * np.exp(-0.2 * rms) * x / rms
+        cos_mean = np.mean(np.cos(2 * np.pi * x))
+        term2 = (2.0 * np.pi / n) * np.exp(cos_mean) * np.sin(2 * np.pi * x)
+        return term1 + term2
 
     @property
     def bounds(self) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
@@ -286,6 +353,166 @@ class RotatedEllipsoid(BenchmarkFunction):
     @property
     def global_minimum(self) -> tuple[NDArray[np.float64], float]:
         return np.zeros(self.dimensions), 0.0
+
+
+class RippledEllipsoid(BenchmarkFunction):
+    """Anisotropic multimodal benchmark: ill-conditioned ellipsoid + Rastrigin-style ripples.
+
+    ``f(x) = sum(scale_i * x_i**2 + amplitude * (1 - cos(2 pi x_i)))``
+
+    The quadratic term gives an anisotropic basin with prescribed condition
+    number; the cosine ripples add many local minima centred at integer
+    coordinates. At the global optimum x = 0 the Hessian is
+    ``diag(2 scale_i + 4 pi**2 amplitude)`` — the ratio of largest to
+    smallest eigenvalue is
+
+        (2 * condition + 4 pi**2 amplitude) / (2 + 4 pi**2 amplitude)
+
+    so for ``condition >> 2 pi**2 amplitude`` the eigenvalues span the
+    full conditioning, while a tighter amplitude/condition ratio keeps
+    multimodality alive across more dimensions.
+
+    Wrap with ``RotatedFunction(...)`` to also couple the curvature
+    off-axis — that is the regime where L-BFGS-B with B_0 = I has the
+    hardest time and where the CMA-ES C^{-1} handoff should win.
+    """
+
+    def __init__(
+        self,
+        dimensions: int,
+        condition: float = 100.0,
+        amplitude: float = 10.0,
+        bound: float = 5.12,
+    ):
+        super().__init__(dimensions)
+        self.condition = condition
+        self.amplitude = amplitude
+        self.bound = bound
+        n = dimensions
+        if n == 1:
+            self._scales = np.array([1.0])
+        else:
+            self._scales = condition ** (np.arange(n) / (n - 1))
+
+    def __call__(self, x: NDArray[np.float64]) -> float:
+        quad = float(np.sum(self._scales * x**2))
+        ripples = float(self.amplitude * np.sum(1.0 - np.cos(2.0 * np.pi * x)))
+        return quad + ripples
+
+    def gradient(self, x: NDArray[np.float64]) -> NDArray[np.float64]:
+        quad_grad = 2.0 * self._scales * x
+        ripple_grad = 2.0 * np.pi * self.amplitude * np.sin(2.0 * np.pi * x)
+        return quad_grad + ripple_grad
+
+    @property
+    def bounds(self) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+        return -self.bound * np.ones(self.dimensions), self.bound * np.ones(self.dimensions)
+
+    @property
+    def global_minimum(self) -> tuple[NDArray[np.float64], float]:
+        return np.zeros(self.dimensions), 0.0
+
+
+class RotatedFunction(BenchmarkFunction):
+    """Generic rotation wrapper for any BenchmarkFunction with a gradient.
+
+    ``f_rotated(x) = f_base(R @ x)``
+
+    so the global optimum at z=0 in the base function (when present) maps
+    back to x=0 in the rotated function — origin-centred problems stay
+    origin-centred. Bounds are inherited from the base function and
+    interpreted in *x-space*; the rotated z = R @ x may go outside the
+    base's typical range, which is fine for analytic functions defined
+    everywhere.
+
+    The local Hessian of the rotated function at x is
+    ``R^T H_base(R x) R``, so any anisotropy in the base function's
+    curvature becomes coupled (off-diagonal) in coordinates. This is what
+    makes the rotation useful for demonstrating that L-BFGS-B with
+    B_0 = I cannot recover the coupling without enough corrections.
+
+    Rotation modes: same as ``RotatedEllipsoid``
+    ("uniform_45" / "golden" / "random" / supplied matrix).
+    """
+
+    def __init__(
+        self,
+        base: BenchmarkFunction,
+        rotation: str | NDArray[np.float64] = "random",
+        seed: int = 0,
+        name_suffix: str | None = None,
+    ):
+        super().__init__(base.dimensions)
+        if not hasattr(base, "gradient"):
+            raise ValueError(
+                f"Base function {type(base).__name__} has no gradient method; "
+                f"RotatedFunction needs it to compute the rotated gradient."
+            )
+        self.base = base
+        self.rotation_matrix = self._build_rotation(rotation, seed)
+        self.rotation_name = (
+            name_suffix or (rotation if isinstance(rotation, str) else "custom")
+        )
+
+    def _build_rotation(
+        self, rotation: str | NDArray[np.float64], seed: int
+    ) -> NDArray[np.float64]:
+        if isinstance(rotation, np.ndarray):
+            matrix = np.asarray(rotation, dtype=float)
+            if matrix.shape != (self.dimensions, self.dimensions):
+                raise ValueError(
+                    f"Rotation matrix shape {matrix.shape} doesn't match "
+                    f"dimension {self.dimensions}."
+                )
+            return matrix
+        n = self.dimensions
+        if rotation == "uniform_45":
+            angles = [np.radians(45)] * (n - 1)
+            return self._givens_chain(angles)
+        if rotation == "golden":
+            golden = np.radians(137.5)
+            angles = [(k + 1) * golden for k in range(n - 1)]
+            return self._givens_chain(angles)
+        if rotation == "random":
+            rng = np.random.default_rng(seed)
+            q, r = np.linalg.qr(rng.standard_normal((n, n)))
+            q *= np.sign(np.diag(r))  # det = +1
+            return q
+        raise ValueError(
+            f"Unknown rotation mode {rotation!r}; use 'uniform_45', 'golden', "
+            f"'random', or pass an explicit matrix."
+        )
+
+    def _givens_chain(self, angles: list[float]) -> NDArray[np.float64]:
+        n = self.dimensions
+        rotation = np.eye(n)
+        for k, angle in enumerate(angles):
+            givens = np.eye(n)
+            c, s = np.cos(angle), np.sin(angle)
+            givens[k, k] = c
+            givens[k, k + 1] = -s
+            givens[k + 1, k] = s
+            givens[k + 1, k + 1] = c
+            rotation = givens @ rotation
+        return rotation
+
+    def __call__(self, x: NDArray[np.float64]) -> float:
+        z = self.rotation_matrix @ x
+        return float(self.base(z))
+
+    def gradient(self, x: NDArray[np.float64]) -> NDArray[np.float64]:
+        z = self.rotation_matrix @ x
+        return self.rotation_matrix.T @ self.base.gradient(z)
+
+    @property
+    def bounds(self) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+        return self.base.bounds
+
+    @property
+    def global_minimum(self) -> tuple[NDArray[np.float64], float]:
+        opt_z, opt_v = self.base.global_minimum
+        # R is orthogonal, so x* = R^T @ z*. For z* = 0 this stays at 0.
+        return self.rotation_matrix.T @ opt_z, opt_v
 
 
 class CEC17Function(BenchmarkFunction):


### PR DESCRIPTION
**Stacks on top of #8 (`lbfgs-implementation`). Review that one first.**

## Summary

A reusable, fair-comparison benchmarking framework for evolutionary optimizers, plus the CMA-ES → L-BFGS-B handoff study built on top of it. The framework lives under `src/benchmarking/` and the study under `examples/` + `docs/`.

Five focused commits:

1. **`feat(cmaes)`** — handoff-friendly CMA-ES API. Renames `CMAESwOptimizer` → `CMAESOptimizer`, exposes `get_eigendecomposition()` / `sigma` / `mean` so callers can build `C^{-1}` without an external `eigh`/`inv`, and fixes a pre-existing population-completion bug that asserted in `_cma.tell()` when the budget elapsed mid-population.
2. **`feat(benchmark-functions)`** — `Griewank` with analytical gradient, analytical gradients for `Rastrigin` and `Ackley`, generic `RotatedFunction` wrapper, and `RippledEllipsoid` (anisotropic quadratic + cosine ripples with separate `condition` and `amplitude` knobs). Gradients verified vs central differences at error 1e-9 to 1e-11.
3. **`feat(benchmarking)`** — the framework: `Problem` with deterministic `starting_point(seed)`, `AlgorithmRun` protocol with `SingleAlgorithm` and `CMAESLBFGSBHandoff` (transforms: `inverse`, `sigma_inverse`, `identity`), `Benchmark` orchestrator with optional joblib-based parallel execution, `BenchmarkPlotter` (median+IQR convergence + boxplot), `RunTrace` with handoff metadata in both evals and CMA-ES generations, JSON/CSV persistence. Adds `joblib` as a dependency.
4. **`feat(examples)`** — seven scripts driving the framework: `multimodal_handoff_benchmark.py`, `handoff_timing_sweep.py`, `rotated_multimodal_handoff.py`, `rippled_ellipsoid_handoff.py`, `rippled_handoff_timing_sweep.py`, `per_experiment_timing_sweep.py`, `regen_report_plots.py`.
5. **`docs`** — `docs/covariance_handoff_when_it_matters.md`: full writeup of when the handoff covariance matters, with five embedded plots and reproducer commands. Includes the resolution of the original "identity matches C⁻¹ on Rastrigin/Griewank" puzzle (Rastrigin's local Hessian is `(2 + 40π²)·I` — exactly isotropic) and the regimes where C⁻¹ wins by 1–4 orders of magnitude.

## Key empirical findings (full numbers in the doc)

- **Rotated ellipsoid (reproduction of supervisor study)**: C⁻¹ 13× better than identity at d=50, m=5, cond=10⁶.
- **Near-unimodal rotated RippledEllipsoid (amp=0.1)**: C⁻¹ wins by 13×–35 000× depending on dimension.
- **Multimodal rotated (amp=1) + tight budget**: C⁻¹ consistently 2–4× better than identity; both beat L-BFGS-B alone.
- **Warmup timing sweet spot**: around 100–200 CMA-ES generations for the d=30 amp=0.1 case; beyond that, CMA-ES's σ collapse poisons `C⁻¹` via `persist_initial_hessian=True` (flagged as follow-up).

## Test plan

- [ ] `pdm install` resolves with the new `joblib` dependency
- [ ] `PYTHONPATH=. pdm run python examples/multimodal_handoff_benchmark.py --include-identity-baseline --num-workers 6 --num-seeds 5 --output-dir /tmp/bench` — quick sanity run on Rastrigin + Griewank
- [ ] `PYTHONPATH=. pdm run python examples/per_experiment_timing_sweep.py --family reproduce_old --num-seeds 5` — confirms the reproduction of the old 13× C⁻¹ finding
- [ ] `PYTHONPATH=. pdm run python examples/regen_report_plots.py` — re-renders the five report plots from `traces.json` without re-running the optimizers (sanity-checks persistence)
- [ ] Read `docs/covariance_handoff_when_it_matters.md` end-to-end; verify the embedded plots load and the reproducer commands run

## Known follow-ups (out of scope for this PR)

- Long-warmup C⁻¹ scale collapse: try `transform="sigma_inverse"` or drop `persist_initial_hessian` for handoff-derived `B_0`.
- Unify `BenchmarkPlotter` and the legacy `MultiAlgorithmPlotter` into a single plotter that handles both single-run multi-panel and multi-seed statistical views (deferred per supervisor decision).
- Make L-BFGS-B's active-set logic actually engage by adding a shifted `RippledEllipsoid` variant whose optimum sits on or near a box face (currently bounds are passive in all five experiments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)