### PR TITLE
refactor(benchmarking): BenchmarkAlgorithm + HandoffAlgorithm ABCs

### DIFF
--- a/src/benchmarking/__init__.py
+++ b/src/benchmarking/__init__.py
@@ -17,7 +17,10 @@ Quick example:
 
 from src.benchmarking.algorithm_run import (
     AlgorithmRun,
+    BenchmarkAlgorithm,
     CMAESLBFGSBHandoff,
+    HandoffAlgorithm,
+    HandoffTransform,
     SingleAlgorithm,
 )
 from src.benchmarking.benchmark import Benchmark
@@ -34,8 +37,11 @@ from src.benchmarking.run_trace import RunTrace
 __all__ = [
     "AlgorithmRun",
     "Benchmark",
+    "BenchmarkAlgorithm",
     "BenchmarkPlotter",
     "CMAESLBFGSBHandoff",
+    "HandoffAlgorithm",
+    "HandoffTransform",
     "Problem",
     "RunTrace",
     "SingleAlgorithm",

--- a/src/benchmarking/algorithm_run.py
+++ b/src/benchmarking/algorithm_run.py
@@ -1,14 +1,37 @@
 """Algorithm specifications for benchmarking.
 
-Each AlgorithmRun knows how to run itself on a Problem given an x0 and a
-seed, and reports a RunTrace. Concrete classes:
+The framework only needs three things from anything you put inside a
+:class:`~src.benchmarking.Benchmark`:
 
-- SingleAlgorithm: any registered AlgorithmFactory algorithm.
-- CMAESLBFGSBHandoff: warm-up CMA-ES, transform its covariance into B_0
-  for L-BFGS-B, then continue from the CMA-ES mean.
+- ``name``  — appears in legends, summary tables, and persisted traces
+- ``color`` — hex string the plotter uses for this algorithm's line
+- ``run(problem, x0, seed)`` — returns a :class:`RunTrace`
+
+How you provide them determines which base class to pick:
+
+==============================  ===========================================
+Your runner is...               Inherit from
+==============================  ===========================================
+one optimizer from the          :class:`SingleAlgorithm` (concrete, just
+factory, no special wrapping    instantiate it).
+warmup -> refinement, two       :class:`HandoffAlgorithm`. Implement
+phases that share state via     ``run_phases()``; the base class stitches
+local variables                 traces, clamps fitness, and fills in
+                                handoff metadata for you.
+anything else (3+ phases,       :class:`BenchmarkAlgorithm`. Implement
+restarts, wrappers, custom      ``run()``; use ``trace_from_result()`` to
+schedules)                      package an :class:`OptimizationResult`
+                                into a :class:`RunTrace`.
+already a class, can't          conform to the :class:`AlgorithmRun`
+inherit                         :class:`Protocol` — just expose ``name``,
+                                ``color``, and ``run()``. No inheritance
+                                required.
+==============================  ===========================================
 """
 
-from dataclasses import dataclass, field
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import StrEnum
 from typing import Callable, Protocol, runtime_checkable
 
 import numpy as np
@@ -20,15 +43,43 @@ from src.algorithms.lbfgsb.config import LBFGSBConfig
 from src.benchmarking.problem import Problem
 from src.benchmarking.run_trace import RunTrace
 from src.core.algorithm_factory import AlgorithmFactory
+from src.core.base_optimizer import OptimizationResult
 from src.core.config_base import BaseConfig
 
 
 _EIGENVALUE_FLOOR = 1e-30
 
 
+class HandoffTransform(StrEnum):
+    """How to turn the CMA-ES covariance into an L-BFGS-B initial Hessian.
+
+    Used by :class:`CMAESLBFGSBHandoff`.
+    """
+
+    INVERSE = "inverse"
+    """Use ``C^{-1}`` directly. The L-BFGS-B model becomes a true quadratic
+    approximation of the CMA-ES posterior around the warm-up mean."""
+
+    SIGMA_INVERSE = "sigma_inverse"
+    """Use ``(sigma^2 C)^{-1}`` — accounts for the CMA-ES global step-size
+    scaling. Sometimes more conservative than the bare inverse."""
+
+    IDENTITY = "identity"
+    """Drop the covariance and use the L-BFGS-B default (B_0 = I). Mainly a
+    control experiment: isolates the value of *passing covariance information*
+    from the value of *sharing a starting point* with CMA-ES."""
+
+
 @runtime_checkable
 class AlgorithmRun(Protocol):
-    """An algorithm spec: name, color, and a runner."""
+    """Duck-typed interface for anything :class:`~src.benchmarking.Benchmark` consumes.
+
+    For most use cases prefer subclassing :class:`BenchmarkAlgorithm` —
+    same three-attribute contract, plus you get the
+    :py:meth:`BenchmarkAlgorithm.trace_from_result` helper. The Protocol
+    is here for the case where you can't inherit (e.g. you're adapting
+    an existing class) and just want to conform structurally.
+    """
 
     name: str
     color: str
@@ -41,15 +92,84 @@ class AlgorithmRun(Protocol):
     ) -> RunTrace: ...
 
 
-def _enable_diagnostics(config: BaseConfig) -> None:
-    """Make sure best-fitness logging is on (it usually is by default)."""
-    if hasattr(config, "diag_bestVal"):
-        config.diag_bestVal = True
+class BenchmarkAlgorithm(ABC):
+    """Base class for anything you can plug into a :class:`Benchmark`.
+
+    Subclasses provide:
+
+    - ``name`` and ``color`` (typically as :py:func:`dataclasses.dataclass` fields).
+    - :py:meth:`run`, which executes the algorithm on one
+      ``(problem, x0, seed)`` triple and returns a :class:`RunTrace`.
+
+    The :py:meth:`trace_from_result` helper packages a single
+    :class:`OptimizationResult` into a :class:`RunTrace` for the common
+    one-optimizer case. Multi-phase runners with their own stitching
+    rules (handoffs, restarts) skip the helper and assemble the trace
+    by hand, or use :class:`HandoffAlgorithm` for the standard two-phase
+    pattern.
+
+    Minimal subclass::
+
+        @dataclass
+        class MyAlgorithm(BenchmarkAlgorithm):
+            name: str
+            color: str
+            # ... whatever config fields you need ...
+
+            def run(self, problem, x0, seed) -> RunTrace:
+                result = ...  # run an optimizer
+                return self.trace_from_result(problem, seed, result)
+    """
+
+    name: str
+    color: str
+
+    @abstractmethod
+    def run(
+        self,
+        problem: Problem,
+        x0: NDArray[np.float64],
+        seed: int,
+    ) -> RunTrace:
+        """Run the algorithm on one (problem, x0, seed) triple."""
+        ...
+
+    def trace_from_result(
+        self,
+        problem: Problem,
+        seed: int,
+        result: OptimizationResult,
+    ) -> RunTrace:
+        """Package a single :class:`OptimizationResult` into a :class:`RunTrace`.
+
+        Handles the common case where one optimizer call produces the
+        whole convergence trace. ``result.diagnostic`` is expected to
+        carry ``evaluations`` and ``best_fitness`` (every built-in
+        LogData does).
+
+        For multi-phase runners with custom stitching rules, build the
+        :class:`RunTrace` by hand instead — or use
+        :class:`HandoffAlgorithm`, which handles the two-phase case.
+        """
+        return RunTrace(
+            algorithm=self.name,
+            problem=problem.name,
+            seed=seed,
+            evaluations=list(result.diagnostic.evaluations),
+            best_fitness=list(result.diagnostic.best_fitness),
+            final_evaluations=result.evaluations,
+            final_fitness=float(result.best_fitness),
+        )
 
 
 @dataclass
-class SingleAlgorithm:
-    """A single optimizer registered in the AlgorithmFactory."""
+class SingleAlgorithm(BenchmarkAlgorithm):
+    """A single optimizer registered in the :class:`AlgorithmFactory`.
+
+    Concrete — instantiate directly with the optimizer choice and a
+    config factory; no subclass needed unless you want to override
+    :py:meth:`run`.
+    """
 
     name: str
     color: str
@@ -67,7 +187,6 @@ class SingleAlgorithm:
         seed: int,
     ) -> RunTrace:
         config = self.config_factory(problem.dimensions)
-        _enable_diagnostics(config)
         for flag in self.extra_diagnostics:
             if hasattr(config, flag):
                 setattr(config, flag, True)
@@ -76,7 +195,7 @@ class SingleAlgorithm:
         if problem.gradient is not None and self.algorithm == AlgorithmChoice.LBFGSB:
             kwargs["gradient_fn"] = problem.gradient
 
-        optimizer = AlgorithmFactory.create_optimizer(
+        result = AlgorithmFactory.create_optimizer(
             self.algorithm,
             problem.function,
             x0,
@@ -85,50 +204,133 @@ class SingleAlgorithm:
             upper_bounds=problem.upper_bound,
             seed=seed,
             **kwargs,
-        )
-        result = optimizer.optimize()
+        ).optimize()
+
+        return self.trace_from_result(problem, seed, result)
+
+
+class HandoffAlgorithm(BenchmarkAlgorithm):
+    """Two-phase (warm-up -> refinement) handoff base class.
+
+    Saves the trace-stitching boilerplate every handoff would otherwise
+    re-implement. Subclasses provide ``name`` + ``color`` (typically via
+    :py:func:`dataclasses.dataclass`) and override :py:meth:`run_phases`
+    to return the two phase results. The base class fills in a
+    :class:`RunTrace` with:
+
+    - eval counts in the refinement segment offset by the warm-up's
+      total evaluations, so the convergence trace is continuous;
+    - the refinement segment's fitness clamped to never exceed the
+      warm-up's best (the refinement logger reports its own best, which
+      starts at ``f(x0_refinement)`` — that may be slightly worse than
+      the warm-up's running best);
+    - ``handoff_eval`` and ``handoff_iter`` set from the warm-up totals,
+      which the plotter uses to draw vertical handoff markers.
+
+    Minimal usage::
+
+        @dataclass
+        class MyHandoff(HandoffAlgorithm):
+            name: str
+            color: str
+            # ... whatever config fields you need ...
+
+            def run_phases(self, problem, x0, seed):
+                warmup_result   = ...  # run phase 1
+                refinement_result = ...  # run phase 2, using warmup state
+                return warmup_result, refinement_result
+
+    Pass state from warm-up to refinement through ordinary local
+    variables in :py:meth:`run_phases` — both phases live in the same
+    method so any state from one is in scope for the other.
+
+    For more elaborate runners (3+ phases, restarts, conditional
+    branches), subclass :class:`BenchmarkAlgorithm` directly instead.
+    """
+
+    @abstractmethod
+    def run_phases(
+        self,
+        problem: Problem,
+        x0: NDArray[np.float64],
+        seed: int,
+    ) -> tuple[OptimizationResult, OptimizationResult]:
+        """Run the two phases. Return ``(warmup_result, refinement_result)``."""
+        ...
+
+    def run(
+        self,
+        problem: Problem,
+        x0: NDArray[np.float64],
+        seed: int,
+    ) -> RunTrace:
+        warmup, refinement = self.run_phases(problem, x0, seed)
+        return self._stitch_traces(problem, seed, warmup, refinement)
+
+    def _stitch_traces(
+        self,
+        problem: Problem,
+        seed: int,
+        warmup: OptimizationResult,
+        refinement: OptimizationResult,
+    ) -> RunTrace:
+        """Concatenate the two phases into a single continuous trace."""
+        warmup_evals = warmup.evaluations
+        warmup_iters = len(warmup.diagnostic.iteration)
+        warmup_best = float(warmup.best_fitness)
+
+        warmup_eval_list = list(warmup.diagnostic.evaluations)
+        warmup_fitness_list = list(warmup.diagnostic.best_fitness)
+        # Offset refinement eval counts so the trace is continuous.
+        refinement_eval_list = [
+            evaluation + warmup_evals
+            for evaluation in refinement.diagnostic.evaluations
+        ]
+        # Clamp refinement fitness so it never reports worse than the
+        # warm-up's best — its first point is f(x0_refinement) which can
+        # be slightly worse than the warm-up's running minimum.
+        refinement_fitness_list = [
+            min(value, warmup_best) for value in refinement.diagnostic.best_fitness
+        ]
 
         return RunTrace(
             algorithm=self.name,
             problem=problem.name,
             seed=seed,
-            evaluations=list(result.diagnostic.evaluations),
-            best_fitness=list(result.diagnostic.best_fitness),
-            final_evaluations=result.evaluations,
-            final_fitness=float(result.best_fitness),
+            evaluations=warmup_eval_list + refinement_eval_list,
+            best_fitness=warmup_fitness_list + refinement_fitness_list,
+            final_evaluations=warmup_evals + refinement.evaluations,
+            final_fitness=min(warmup_best, float(refinement.best_fitness)),
+            handoff_eval=warmup_evals,
+            handoff_iter=warmup_iters,
         )
 
 
 @dataclass
-class CMAESLBFGSBHandoff:
-    """CMA-ES warm-up followed by L-BFGS-B with a covariance-derived B_0.
+class CMAESLBFGSBHandoff(HandoffAlgorithm):
+    """CMA-ES warm-up followed by L-BFGS-B with a covariance-derived ``B_0``.
 
     Steps:
 
     1. Run CMA-ES on the problem until ``cmaes_config.budget`` evaluations
-       are consumed. Same seed and same x0 as a standalone CMA-ES run will
-       produce an identical CMA-ES prefix in the convergence trace.
-    2. Read the cached eigendecomposition (B, D) from CMA-ES.
-    3. Compose the initial Hessian for L-BFGS-B according to ``transform``:
-       - "inverse" (default) -> C^{-1}
-       - "sigma_inverse"      -> (sigma^2 C)^{-1}
-       - "identity"           -> no Hessian info (L-BFGS-B default B_0 = I);
-                                 isolates the value of just sharing the
-                                 starting point with CMA-ES.
-    4. Run L-BFGS-B from the CMA-ES mean with that B_0 and a separate
+       are consumed. Same seed and same ``x0`` as a standalone CMA-ES run
+       will produce an identical CMA-ES prefix in the convergence trace.
+    2. Read the cached eigendecomposition ``(B, D)`` from CMA-ES.
+    3. Compose the initial Hessian for L-BFGS-B according to
+       :attr:`transform` (see :class:`HandoffTransform`).
+    4. Run L-BFGS-B from the CMA-ES mean with that ``B_0`` and a separate
        budget.
 
-    The convergence trace is the concatenation of the two phases. The
-    L-BFGS-B segment is clamped so it never reports a fitness worse than
-    the CMA-ES handoff value (handles cases where L-BFGS-B's first step
-    happens to land slightly worse than the warm-up's best).
+    Trace stitching, fitness clamping, and handoff metadata are inherited
+    from :class:`HandoffAlgorithm`; this class only owns the
+    CMA-ES-specific covariance transformation.
     """
 
     name: str
     color: str
     cmaes_config_factory: Callable[[int], CMAESConfig]
     lbfgsb_config_factory: Callable[[int], LBFGSBConfig]
-    transform: str = "inverse"
+    transform: HandoffTransform | str = HandoffTransform.INVERSE
 
     cmaes_extra_diagnostics: tuple[str, ...] = ("diag_eigen",)
     lbfgsb_extra_diagnostics: tuple[str, ...] = ()
@@ -139,7 +341,8 @@ class CMAESLBFGSBHandoff:
         eigenvalues_sqrt: NDArray[np.float64],
         sigma: float,
     ) -> NDArray[np.float64] | None:
-        if self.transform == "identity":
+        transform = str(self.transform)
+        if transform == HandoffTransform.IDENTITY:
             return None
 
         eigenvalues = np.maximum(eigenvalues_sqrt**2, _EIGENVALUE_FLOOR)
@@ -148,26 +351,25 @@ class CMAESLBFGSBHandoff:
         # are still valid but numpy raises spurious divide/overflow warnings
         # on the intermediates.
         with np.errstate(over="ignore", divide="ignore", invalid="ignore"):
-            if self.transform == "inverse":
+            if transform == HandoffTransform.INVERSE:
                 return (eigenvectors * (1.0 / eigenvalues)) @ eigenvectors.T
-            if self.transform == "sigma_inverse":
+            if transform == HandoffTransform.SIGMA_INVERSE:
                 inverse = (eigenvectors * (1.0 / eigenvalues)) @ eigenvectors.T
                 return inverse / (sigma * sigma)
 
+        valid = ", ".join(repr(value.value) for value in HandoffTransform)
         raise ValueError(
-            f"Unknown handoff transform: {self.transform!r}. "
-            f"Use 'inverse', 'sigma_inverse', or 'identity'."
+            f"Unknown handoff transform: {self.transform!r}. Use one of {valid}."
         )
 
-    def run(
+    def run_phases(
         self,
         problem: Problem,
         x0: NDArray[np.float64],
         seed: int,
-    ) -> RunTrace:
+    ) -> tuple[OptimizationResult, OptimizationResult]:
         # Phase 1: CMA-ES warm-up.
         cmaes_config = self.cmaes_config_factory(problem.dimensions)
-        _enable_diagnostics(cmaes_config)
         for flag in self.cmaes_extra_diagnostics:
             if hasattr(cmaes_config, flag):
                 setattr(cmaes_config, flag, True)
@@ -182,62 +384,34 @@ class CMAESLBFGSBHandoff:
             seed=seed,
         )
         cmaes_result = cmaes_optimizer.optimize()
-        warmup_evals = cmaes_result.evaluations
-        warmup_iters = len(cmaes_result.diagnostic.iteration)
 
+        # Pull CMA-ES internal state for the handoff: the eigendecomposition
+        # of the covariance and the current mean become L-BFGS-B's B_0
+        # and starting point respectively.
         eigenvectors, eigenvalues_sqrt = cmaes_optimizer.get_eigendecomposition()
-        sigma = cmaes_optimizer.sigma
-        starting_point = cmaes_optimizer.mean
-        cmaes_best = float(cmaes_result.best_fitness)
-
-        # Phase 2: L-BFGS-B with a covariance-derived B_0.
         initial_hessian = self._initial_hessian_from_cmaes(
-            eigenvectors, eigenvalues_sqrt, sigma
+            eigenvectors, eigenvalues_sqrt, cmaes_optimizer.sigma,
         )
 
+        # Phase 2: L-BFGS-B from the CMA-ES mean with the derived B_0.
         lbfgsb_config = self.lbfgsb_config_factory(problem.dimensions)
         lbfgsb_config.initial_hessian = initial_hessian
-        _enable_diagnostics(lbfgsb_config)
         for flag in self.lbfgsb_extra_diagnostics:
             if hasattr(lbfgsb_config, flag):
                 setattr(lbfgsb_config, flag, True)
 
-        kwargs: dict = {}
+        lbfgsb_kwargs: dict = {}
         if problem.gradient is not None:
-            kwargs["gradient_fn"] = problem.gradient
+            lbfgsb_kwargs["gradient_fn"] = problem.gradient
 
-        lbfgsb_optimizer = AlgorithmFactory.create_optimizer(
+        lbfgsb_result = AlgorithmFactory.create_optimizer(
             AlgorithmChoice.LBFGSB,
             problem.function,
-            starting_point,
+            cmaes_optimizer.mean,
             lbfgsb_config,
             lower_bounds=problem.lower_bound,
             upper_bounds=problem.upper_bound,
-            **kwargs,
-        )
-        lbfgsb_result = lbfgsb_optimizer.optimize()
+            **lbfgsb_kwargs,
+        ).optimize()
 
-        # Concatenate traces. Offset L-BFGS-B evals so the trace is continuous,
-        # and clamp its fitness to never exceed the handoff value (the L-BFGS-B
-        # logger reports its own best, which starts at f(x0_lbfgsb), not f_best).
-        cmaes_evals = list(cmaes_result.diagnostic.evaluations)
-        cmaes_fits = list(cmaes_result.diagnostic.best_fitness)
-        lbfgsb_evals = [
-            evaluation + warmup_evals
-            for evaluation in lbfgsb_result.diagnostic.evaluations
-        ]
-        lbfgsb_fits = [min(value, cmaes_best) for value in lbfgsb_result.diagnostic.best_fitness]
-
-        final_fitness = min(cmaes_best, float(lbfgsb_result.best_fitness))
-
-        return RunTrace(
-            algorithm=self.name,
-            problem=problem.name,
-            seed=seed,
-            evaluations=cmaes_evals + lbfgsb_evals,
-            best_fitness=cmaes_fits + lbfgsb_fits,
-            final_evaluations=warmup_evals + lbfgsb_result.evaluations,
-            final_fitness=final_fitness,
-            handoff_eval=warmup_evals,
-            handoff_iter=warmup_iters,
-        )
+        return cmaes_result, lbfgsb_result


### PR DESCRIPTION
## Summary

Adds a layered class hierarchy for anything that runs inside a `Benchmark`,
making the extension points obvious by progressively narrowing the abstract
contract:

```
BenchmarkAlgorithm        — generic ABC; implement run() yourself
  SingleAlgorithm         — concrete: wraps one optimizer
  HandoffAlgorithm        — ABC: two-phase warmup -> refinement;
                            base class stitches traces
    CMAESLBFGSBHandoff    — pre-built CMA-ES -> L-BFGS-B handoff
```

`BenchmarkAlgorithm` carries the minimum contract (`name`, `color`, `run()`)
plus a `trace_from_result()` helper that packages a single
`OptimizationResult` into a `RunTrace`.

`HandoffAlgorithm` encapsulates the trace-stitching boilerplate every
two-phase handoff would otherwise have to re-implement: eval-count
offsets, refinement-fitness clamping, and the `handoff_eval` /
`handoff_iter` metadata the plotter uses for vertical markers.
Subclasses just override `run_phases()` returning a `(warmup, refinement)` tuple.

Also adds `HandoffTransform` `StrEnum` (`INVERSE` / `SIGMA_INVERSE` / `IDENTITY`)
for the `CMAESLBFGSBHandoff.transform` parameter — string call sites
keep working unchanged because StrEnum members compare equal to their values.

The `AlgorithmRun` Protocol is unchanged and still available for cases
where inheritance isn't viable (adapting external classes). The module
docstring spells out which base class to pick for each case.

## Internal refactors (no API change)

- `SingleAlgorithm` now inherits from `BenchmarkAlgorithm` and uses
  `trace_from_result()` instead of duplicating the `RunTrace` construction.
- `CMAESLBFGSBHandoff` inherits from `HandoffAlgorithm`; its `run()` method
  and ~40 lines of trace stitching are gone, replaced by a single
  `run_phases()` method that owns only the CMA-ES-specific covariance
  transformation.

## Public API is unchanged

Constructors accept the same arguments and produce the same `RunTrace`
output as before. Every existing experiment using `SingleAlgorithm`,
`CMAESLBFGSBHandoff`, or `transform="inverse"`-style string calls
continues to work without changes.

## Test plan

- [x] `SingleAlgorithm` runs unchanged on `experiments/handoff/multimodal.py`
  (Griewank d=10, 3 seeds: median fitness matches pre-refactor)
- [x] `CMAESLBFGSBHandoff` runs unchanged with both string and enum transform
- [x] `HandoffAlgorithm` subclass-ability verified by [the custom-handoff demo](https://github.com/jedrzej-grabski/declivity/blob/plotter-redesign/experiments/basic/custom_handoff.py) on the stacked plotter branch (DES -> L-BFGS-B converges to 3.1e-10 on 10D Rosenbrock)
- [x] `BenchmarkAlgorithm` subclass-ability verified by [the multi-start demo](https://github.com/jedrzej-grabski/declivity/blob/plotter-redesign/experiments/basic/custom_algorithm.py) on the stacked plotter branch (10 seeds × Rastrigin 10D)
- [x] All imports green via the existing benchmarking module

## Companion PR

The plotter redesign sits on top of this: \`plotter-redesign\` branch.
Recommended merge order: this PR first, then the plotter one.