### PR TITLE
docs: update README/DOCUMENTATION; add framework_design.md

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -17,7 +17,7 @@ DES, CMA-ES, MF-CMA-ES, and L-BFGS-B.
 - [Benchmark functions](#benchmark-functions)
 - [Boundary handling](#boundary-handling)
 - [Logging and diagnostics](#logging-and-diagnostics)
-- [Visualization](#visualization)
+- [Plotting (declarative panel system)](#plotting-declarative-panel-system)
 - [Benchmarking framework](#benchmarking-framework)
 - [CMA-ES → L-BFGS-B handoff](#cma-es--l-bfgs-b-handoff)
 - [API reference](#api-reference)
@@ -37,21 +37,46 @@ src/
 │                          ring_buffer, initial_point_generator, repair_strategy,
 │                          covariance
 ├── logging/               BaseLogger + per-algorithm loggers + LoggerFactory
-├── plotting/              MultiAlgorithmPlotter (single-run multi-panel views)
-└── benchmarking/          Problem, AlgorithmRun, Benchmark, BenchmarkPlotter,
-                           RunTrace, persistence (multi-seed comparison framework)
+│                          BaseLogData (minimal) + PopulationLogData (extends)
+├── plotting/              Declarative panel system:
+│                            panel.py            — Panel, Series, PanelRegistry
+│                            types.py            — PanelKey, YScale, XAxis,
+│                                                  LineStyle, PanelSet (StrEnum)
+│                            declarative.py      — plot_metrics, plot_comparison,
+│                                                  plot_evaluation_bars
+│                            benchmark.py        — plot_benchmark_convergence,
+│                                                  plot_benchmark_boxplot
+│                            landscape.py        — plot_function_landscape(_grid)
+│                            diagnostics.py      — plot_matrix_diagonal_comparison
+│                            standard_panels.py  — 30+ panel registrations
+└── benchmarking/          Problem, Benchmark, RunTrace, persistence
+                           BenchmarkAlgorithm (ABC)
+                             ├── SingleAlgorithm
+                             └── HandoffAlgorithm (ABC)
+                                   └── CMAESLBFGSBHandoff
+                           AlgorithmRun (Protocol) + HandoffTransform (StrEnum)
 ```
 
-Three high-level concepts:
+Five high-level concepts:
 
 1. **Factory** — `AlgorithmFactory.create_optimizer(algorithm, func, x0, config, ...)`
    returns a typed `BaseOptimizer[LogData, Config]` instance. Wraps construction
    so callers don't need to import per-algorithm classes.
 2. **Generic base** — `BaseOptimizer[LogDataType, ConfigType]` enforces a typed
    `optimize() -> OptimizationResult[LogDataType]` contract per algorithm.
-3. **Diagnostics are opt-in** — each config has `diag_*` flags. `diag_bestVal`
-   is on by default; everything else costs memory or time so you enable it
-   explicitly. `config.enable_all_diagnostics()` flips them all on.
+3. **LogData hierarchy** — `BaseLogData` carries the universal fields every
+   algorithm logs (iteration, evaluations, best_fitness, best_solution);
+   `PopulationLogData` extends it for evolutionary algorithms with
+   worst/mean/std/population/eigenvalues. Single-point methods (L-BFGS-B)
+   inherit `BaseLogData` directly.
+4. **Declarative plotting** — `Panel` specs registered against algorithms
+   describe what to plot; rendering functions consume the registry.
+   Adding a new panel is one `Panel(...)` line. Cross-algorithm semantic
+   keys (`PanelKey.STEP_SIZE` → `sigma`/`Ft`/`step_length`) make
+   `plot_comparison` produce meaningful overlays automatically.
+5. **Benchmark extension hierarchy** — `BenchmarkAlgorithm` ABC, with
+   `HandoffAlgorithm` as a two-phase specialization and `AlgorithmRun`
+   Protocol as the no-inheritance escape hatch.
 
 ## Installation
 
@@ -70,6 +95,7 @@ opfunu (CEC2017), seaborn, joblib.
 import numpy as np
 from src import AlgorithmFactory
 from src.algorithms.choices import AlgorithmChoice
+from src.plotting import plot_metrics
 from src.utils.benchmark_functions import Sphere
 
 func = Sphere(dimensions=10)
@@ -87,11 +113,12 @@ result = optimizer.optimize()
 print(f"f* = {result.best_fitness:.4e}")
 print(f"x* = {result.best_solution}")
 print(f"evals = {result.evaluations}")
-print(f"message = {result.message}")
+
+plot_metrics(result, save_path="cmaes.png")
 ```
 
-The result also carries `result.diagnostic` (the per-algorithm log dataclass)
-and `result.algorithm` (`AlgorithmChoice`).
+The result carries `result.diagnostic` (the per-algorithm LogData) and
+`result.algorithm` (`AlgorithmChoice`).
 
 ## Algorithms
 
@@ -116,7 +143,7 @@ config.pathLength = 6      # evolution-path history length
 config.Lamarckism = False  # if True, repair coordinates inherit into individuals
 ```
 
-Diagnostics: `diag_Ft` logs the per-iteration Ft trajectory.
+Algorithm-specific diagnostic flag: `diag_Ft` logs the per-iteration Ft trajectory.
 
 ### CMA-ES
 
@@ -131,7 +158,6 @@ config = CMAESConfig(dimensions=10)
 config.sigma = 0.0               # 0 ⇒ auto-derive from bounds
 config.population_size = 0       # 0 ⇒ default 4 + ⌊3 ln d⌋
 config.tolfun = 1e-12
-config.tolx = 1e-12 * config.sigma
 config.tolxup = 1e4
 config.tolconditioncov = 1e14
 ```
@@ -142,7 +168,8 @@ Public hooks for handoff scenarios:
 - `optimizer.get_eigendecomposition()` → `(B, D)` where `C = B @ diag(D²) @ Bᵀ`
 - `optimizer.sigma`, `optimizer.mean` — properties on the optimizer
 
-Diagnostics: `diag_sigma`, `diag_cond`, `diag_eigen`, `diag_covariance_matrix`.
+Algorithm-specific diagnostic flags: `diag_sigma`, `diag_covariance_matrix`.
+(Eigenvalues are gated by the base `diag_eigen` flag.)
 
 ### MF-CMA-ES
 
@@ -150,6 +177,10 @@ Arabas's matrix-free CMA-ES. Avoids storing the full covariance by holding
 circular buffers of past steps. Optional **PPMF** (Population-based
 Precision Modification Framework) step-size adaptation can be enabled via
 `config.use_ppmf = True`.
+
+MFCMAES logs `sigma`, `p_succ`, `midpoint_fitness`, `constraint_violations`,
+`pc_norm`, and `mean_vector_norm` unconditionally — no algorithm-specific
+diag flags.
 
 ### L-BFGS-B
 
@@ -188,9 +219,10 @@ Gradient — pass an analytic gradient via the `gradient_fn` keyword on
 `AlgorithmFactory.create_optimizer`; otherwise the optimizer falls back to
 central or forward finite differences (`config.fd_method`).
 
-Diagnostics: `diag_gradient_norm`, `diag_step_length`, `diag_theta`,
-`diag_num_free`, `diag_line_search_iters`. See
-[`docs/lbfgsb_lecture.md`](docs/lbfgsb_lecture.md) and
+Algorithm-specific diagnostic flags: `diag_gradient_norm`, `diag_step_length`,
+`diag_theta`, `diag_num_free`, `diag_line_search_iters`.
+
+See [`docs/lbfgsb_lecture.md`](docs/lbfgsb_lecture.md) and
 [`docs/lbfgsb_initial_hessian_design.md`](docs/lbfgsb_initial_hessian_design.md)
 for internals.
 
@@ -207,22 +239,20 @@ class BaseConfig:
     budget: int = 0          # 0 ⇒ algorithm-specific default
     population_size: int = 0 # 0 ⇒ algorithm-specific default
 
-    # Diagnostic flags (off by default except diag_bestVal)
-    diag_enabled: bool = False
-    diag_value: bool = False
-    diag_mean: bool = False
-    diag_meanCords: bool = False
-    diag_pop: bool = False
-    diag_bestVal: bool = True
-    diag_worstVal: bool = False
-    diag_eigen: bool = False
+    # Diagnostic flags that actually gate logging behavior.
+    diag_pop: bool = False    # store the population each iter (memory-expensive)
+    diag_eigen: bool = False  # compute + log eigenvalues / condition number
 ```
+
+Diagnostic flags are kept lean: only flags that an optimizer or logger
+actually gates on appear. Algorithm-specific flags live on subclass configs
+(e.g. `diag_sigma` on `CMAESConfig`, `diag_Ft` on `DESConfig`).
 
 Helper methods on every config:
 
-- `config.enable_all_diagnostics()` — turns every `diag_*` flag on
+- `config.enable_all_diagnostics()` — turns every `diag_*` flag on (the
+  algorithm's own subclass methods chain via `super()`).
 - `config.disable_all_diagnostics()` — all off
-- `config.with_convergence_diagnostics()` — minimal convergence-only logging
 - `config.to_dict()` — for serialization
 
 Configs can also be built via the factory if you don't want to import the
@@ -291,66 +321,253 @@ custom logic — see `src/utils/boundary_handlers.py`.
 
 ## Logging and diagnostics
 
+### LogData hierarchy
+
+```
+BaseLogData                  — universal fields every algorithm logs
+  └── PopulationLogData      — adds worst / mean / std / population /
+                                eigenvalues / condition_number
+```
+
+`BaseLogData` carries `iteration`, `evaluations`, `best_fitness`, and
+`best_solution`. `PopulationLogData` extends it for evolutionary algorithms.
+Algorithm-specific LogData subclasses add their own fields on top.
+
+| LogData          | Inherits from         | Algorithm-specific fields                        |
+|------------------|-----------------------|--------------------------------------------------|
+| `DESLogData`     | `PopulationLogData`   | `Ft`, `evolution_path`, `step_size`              |
+| `CMAESLogData`   | `PopulationLogData`   | `sigma`, `pc`, `ps`, `mean_vector`, eigen-stats  |
+| `MFCMAESLogData` | `PopulationLogData`   | `sigma`, `p_succ`, `midpoint_fitness`, …         |
+| `LBFGSBLogData`  | `BaseLogData`         | `gradient_norm`, `step_length`, `theta`, …       |
+
+L-BFGS-B is single-point, so `LBFGSBLogData` inherits `BaseLogData`
+directly without the population fields.
+
+### Reading logs
+
 ```python
 result = optimizer.optimize()
-log = result.diagnostic           # the per-algorithm log dataclass
+log = result.diagnostic           # the per-algorithm LogData
 log.best_fitness                  # list[float] — per-iteration best fitness
 log.evaluations                   # list[int]   — eval counter per iteration
 log.iteration                     # list[int]   — iteration index
+log.to_dict()                     # all fields as a dict (for serialization)
 ```
 
-Algorithm-specific fields (only populated when the matching `diag_*` flag
-is on):
+Algorithm-specific fields are only populated when the matching `diag_*`
+flag is on (e.g. `condition_number` requires `diag_eigen=True`).
 
-- **DES**: `Ft` history (`diag_Ft`)
-- **CMA-ES / MF-CMA-ES**: `sigma`, `condition_number`, `eigenvalues`,
-  `mean_vector`, `pc`, `ps`, `covariance_matrix`
-- **L-BFGS-B**: `gradient_norm`, `projected_gradient_norm`, `step_length`,
-  `theta`, `num_free_vars`, `num_corrections`, `line_search_iters`
+## Plotting (declarative panel system)
 
-## Visualization
+The framework ships a declarative plotter built around `Panel` specs:
+**you describe what a panel is**, the registry knows what each algorithm
+exposes, and the rendering functions read both.
 
-Two complementary plotters:
+### Eight entry points
 
-1. **`src.plotting.MultiAlgorithmPlotter`** — single-run multi-panel
-   diagnostic views. Use after an individual `optimizer.optimize()` call.
+All in `src.plotting`:
 
-   ```python
-   from src.plotting.multi_algorithm_plotter import MultiAlgorithmPlotter
+| Function | Use when |
+|---|---|
+| `plot_metrics(result)` | one optimization run, multi-panel deep dive |
+| `plot_comparison(results)` | several runs, semantic-key overlay per panel |
+| `plot_evaluation_bars(results)` | horizontal bar chart of total evaluations |
+| `plot_benchmark_convergence(traces, problems, algorithms)` | multi-seed median + IQR per algorithm |
+| `plot_benchmark_boxplot(traces, problems, algorithms)` | final-fitness distribution per algorithm |
+| `plot_function_landscape(func)` | 2D contour of an objective with optional Hessian arrows |
+| `plot_function_landscape_grid(funcs)` | several landscapes side-by-side |
+| `plot_matrix_diagonal_comparison(matrices, reference)` | sorted-diagonal vs reference matrix |
 
-   plotter = MultiAlgorithmPlotter()
-   plotter.plot_algorithm_specific_metrics(
-       result, AlgorithmChoice.CMAES, save_path="cmaes_metrics.png",
-   )
-   plotter.plot_labeled_convergence_comparison(
-       {"CMA-ES": result_cmaes, "L-BFGS-B": result_lbfgs},
-       colors={"CMA-ES": "#e74c3c", "L-BFGS-B": "#3498db"},
-       title="...",
-       save_path="convergence.png",
-       handoff_eval=2500,    # optional: dashed vertical at handoff point
-   )
-   plotter.plot_function_landscape(func, ...)
-   plotter.plot_function_landscape_grid(funcs_dict, ...)
-   plotter.plot_matrix_diagonal_comparison(matrices, reference=...)
-   plotter.plot_evaluation_bar_chart(results, colors, ...)
-   ```
+### Single-run deep dive
 
-2. **`src.benchmarking.BenchmarkPlotter`** — multi-seed statistical views
-   (median + IQR convergence, final-fitness boxplot). Driven by the
-   benchmarking framework; consumes `RunTrace`s, not raw `OptimizationResult`s.
+```python
+from src.plotting import plot_metrics, PanelKey, PanelSet
 
-The two plotters are deliberately separate today; unifying them is a
-deferred refactor.
+# Default: every panel marked `default=True` for the algorithm.
+plot_metrics(result, save_path="cmaes.png")
+
+# Curated subset.
+plot_metrics(
+    result,
+    panels=[PanelKey.CONVERGENCE, PanelKey.STEP_SIZE, PanelKey.CONDITION_NUMBER],
+    save_path="cmaes_focused.png",
+)
+
+# Everything registered, including non-default panels.
+plot_metrics(result, panels=PanelSet.ALL, save_path="cmaes_all.png")
+```
+
+### Cross-algorithm comparison
+
+```python
+from src.plotting import plot_comparison
+
+plot_comparison(
+    {"CMA-ES": cmaes_result, "L-BFGS-B": lbfgsb_result},
+    colors={"CMA-ES": "#e74c3c", "L-BFGS-B": "#3498db"},
+    save_path="comparison.png",
+)
+# panels=None defaults to PanelRegistry.common([algos]) — the intersection
+# of registered semantic keys. CMA-ES `sigma` and L-BFGS-B `step_length`
+# both register under PanelKey.STEP_SIZE, so they overlay on one axis.
+```
+
+For an L-BFGS-B family comparison with handoff annotation:
+
+```python
+plot_comparison(
+    results,
+    panels=[
+        PanelKey.CONVERGENCE,
+        PanelKey.CONVERGENCE_BY_ITER,
+        PanelKey.PROJECTED_GRADIENT,
+        PanelKey.STEP_SIZE_BY_ITER,
+    ],
+    handoff_eval=2500,    # vertical dashed line on evaluations panels
+    handoff_iter=42,      # vertical dashed line on iteration panels
+)
+```
+
+### Multi-seed benchmark
+
+```python
+from src.plotting import plot_benchmark_convergence, plot_benchmark_boxplot
+
+plot_benchmark_convergence(
+    bench.traces, problems=problems, algorithms=algorithms,
+    show_iqr=True,                # median + 25/75 percentile band
+    annotate_handoff=True,        # auto vertical lines from RunTrace.handoff_eval
+    save_path="convergence.png",
+)
+plot_benchmark_boxplot(
+    bench.traces, problems=problems, algorithms=algorithms,
+    save_path="final_fitness.png",
+)
+```
+
+### Adding a new panel
+
+One line in [`src/plotting/standard_panels.py`](src/plotting/standard_panels.py):
+
+```python
+from src.plotting import Panel, PanelKey, PanelRegistry, YScale
+
+PanelRegistry.register(
+    AlgorithmChoice.CMAES,
+    Panel(
+        key=PanelKey.STEP_SIZE,    # or any string for custom keys
+        title="Step Size",
+        ylabel="σ",
+        field="sigma",             # attribute on the LogData
+        yscale=YScale.LOG,
+        floor=1e-30,               # clip below this for log scale
+        default=True,              # included in plot_metrics(panels=None)
+    ),
+)
+```
+
+Multi-series panels (one panel, several lines on the same axes — like
+the classic best/mean/median view) use `series=` instead of `field=`:
+
+```python
+from src.plotting import Series, LineStyle
+
+Panel(
+    key=PanelKey.CONVERGENCE,
+    title="Convergence",
+    ylabel="Fitness (log)",
+    series=(
+        Series("best_fitness",   "Best",      color="tab:blue"),
+        Series("mean_fitness",   "Mean f(m)", linestyle=LineStyle.DASHED),
+        Series("median_fitness", "Median",    linestyle=LineStyle.DOTTED),
+    ),
+    yscale=YScale.LOG,
+    floor=1e-30,
+)
+```
+
+### StrEnum vocabulary
+
+The user-facing API uses `StrEnum` types so call sites get autocomplete
+and refactor safety. The enums compare equal to their string values —
+existing call sites passing raw strings keep working.
+
+| Enum | Values |
+|---|---|
+| `PanelKey` | All standard semantic keys (CONVERGENCE, STEP_SIZE, CONDITION_NUMBER, …) |
+| `YScale` | LOG, LINEAR |
+| `XAxis` | EVALUATIONS, ITERATION |
+| `LineStyle` | SOLID, DASHED, DOTTED, DASH_DOT |
+| `PanelSet` | DEFAULT, ALL (sentinels for `panels=`) |
+
+```python
+# These are equivalent:
+plot_metrics(result, panels=["convergence", "step_size"])
+plot_metrics(result, panels=[PanelKey.CONVERGENCE, PanelKey.STEP_SIZE])
+```
+
+### Specialized plots
+
+Outside the panel system (they don't fit the per-iteration time-series model):
+
+```python
+from src.plotting import (
+    plot_function_landscape, plot_function_landscape_grid,
+    plot_matrix_diagonal_comparison,
+)
+
+# 2D contour with Hessian eigenvector arrows
+plot_function_landscape(
+    func, title="Rotated Ellipsoid",
+    extent=10.0, resolution=200,
+    show_eigenvectors=True, hessian=func.hessian,
+    save_path="landscape.png",
+)
+
+# Several functions side-by-side
+plot_function_landscape_grid(
+    {"None": ellipsoid, "Random rotation": rotated_ellipsoid},
+    extent=10.0, save_path="landscapes.png",
+)
+
+# Diagonal-profile comparison against a reference matrix
+plot_matrix_diagonal_comparison(
+    {"C^-1": inverse_cov, "Normalized": normalized},
+    reference=true_hessian,
+    save_path="diag_compare.png",
+)
+```
 
 ## Benchmarking framework
 
 `src.benchmarking` is the orchestrator for fair multi-seed comparisons.
 
+### Extension hierarchy
+
+Anything that runs inside a `Benchmark` provides three things: `name`,
+`color`, and `run(problem, x0, seed) -> RunTrace`. Pick the narrowest
+base class that fits:
+
+| Your runner is... | Inherit from |
+|---|---|
+| one optimizer from the factory, no special wrapping | `SingleAlgorithm` (concrete) |
+| warmup → refinement, two phases sharing state | `HandoffAlgorithm` (ABC, implement `run_phases()`) |
+| anything else (restarts, multi-phase, wrappers) | `BenchmarkAlgorithm` (ABC, implement `run()`) |
+| already a class, can't inherit | conform to `AlgorithmRun` Protocol |
+
+`HandoffAlgorithm` handles trace-stitching (eval-count offsets, fitness
+clamping, handoff metadata) so subclasses only describe the two phases.
+`BenchmarkAlgorithm` provides `trace_from_result()` for the common
+single-result → `RunTrace` packaging.
+
+### Standard usage
+
 ```python
 from src.benchmarking import (
-    Benchmark, BenchmarkPlotter, Problem,
-    SingleAlgorithm, CMAESLBFGSBHandoff,
+    Benchmark, Problem,
+    SingleAlgorithm, CMAESLBFGSBHandoff, HandoffTransform,
 )
+from src.plotting import plot_benchmark_convergence, plot_benchmark_boxplot
 from src.utils.benchmark_functions import Rastrigin
 from src.algorithms.choices import AlgorithmChoice
 from src.algorithms.cmaes.config import CMAESConfig
@@ -373,7 +590,7 @@ algorithms = [
         name="CMA-ES + L-BFGS-B", color="#2ecc71",
         cmaes_config_factory=lambda d: CMAESConfig(dimensions=d, budget=2500, sigma=2.0),
         lbfgsb_config_factory=lambda d: LBFGSBConfig(dimensions=d, budget=7500),
-        transform="inverse",   # see [Handoff](#cma-es--l-bfgs-b-handoff)
+        transform=HandoffTransform.INVERSE,    # or "inverse" (StrEnum)
     ),
 ]
 
@@ -387,15 +604,51 @@ bench = Benchmark(
 bench.run(verbose=True)
 bench.print_summary()
 
-plotter = BenchmarkPlotter(
-    problems=[problem], algorithms=algorithms, traces=bench.traces,
-    output_dir="plots/handoff/rastrigin_demo",
+plot_benchmark_convergence(
+    bench.traces, problems=[problem], algorithms=algorithms,
+    save_path="plots/handoff/rastrigin_demo/convergence.png",
 )
-plotter.plot_convergence_grid(save_path="...")
-plotter.plot_final_fitness_boxplot(save_path="...")
+plot_benchmark_boxplot(
+    bench.traces, problems=[problem], algorithms=algorithms,
+    save_path="plots/handoff/rastrigin_demo/final_fitness.png",
+)
 ```
 
-Key invariants:
+### Custom runners
+
+Two worked examples in `experiments/basic/`:
+
+**`custom_handoff.py`** — DES → L-BFGS-B via `HandoffAlgorithm`:
+
+```python
+@dataclass
+class DESLBFGSBHandoff(HandoffAlgorithm):
+    name: str
+    color: str
+    des_config_factory:    Callable[[int], DESConfig]
+    lbfgsb_config_factory: Callable[[int], LBFGSBConfig]
+
+    def run_phases(self, problem, x0, seed):
+        des_result = AlgorithmFactory.create_optimizer(
+            AlgorithmChoice.DES, problem.function, x0,
+            self.des_config_factory(problem.dimensions),
+            lower_bounds=problem.lower_bound, upper_bounds=problem.upper_bound,
+            seed=seed,
+        ).optimize()
+
+        lbfgsb_result = AlgorithmFactory.create_optimizer(
+            AlgorithmChoice.LBFGSB, problem.function, des_result.best_solution,
+            self.lbfgsb_config_factory(problem.dimensions),
+            lower_bounds=problem.lower_bound, upper_bounds=problem.upper_bound,
+        ).optimize()
+
+        return des_result, lbfgsb_result
+```
+
+**`custom_algorithm.py`** — multi-start CMA-ES via `BenchmarkAlgorithm`:
+implements `run()` and stitches a custom multi-restart `RunTrace` by hand.
+
+### Invariants
 
 - **Same seed ⇒ same starting point across all algorithms.** `Problem`
   generates `x0` deterministically from the seed.
@@ -403,24 +656,25 @@ Key invariants:
   CMA-ES**, so the warmup prefix of the handoff exactly matches a
   standalone run up to the handoff point.
 - **Persistence**: every `Benchmark.run()` auto-dumps `traces.json`,
-  `runs.csv`, `summary.csv` (toggleable with `save_artifacts=False`).
+  `runs.csv`, `summary.csv` (toggle with `save_artifacts=False`).
   Restore with `src.benchmarking.persistence.load_traces_json(...)`.
 
 ## CMA-ES → L-BFGS-B handoff
 
 `CMAESLBFGSBHandoff` runs CMA-ES, then hands its learned covariance to
-L-BFGS-B as the initial Hessian `B₀`. Available transforms:
+L-BFGS-B as the initial Hessian `B₀`. The `transform` parameter accepts
+a `HandoffTransform` StrEnum or the equivalent raw string:
 
-| `transform=`     | `B₀` becomes        | Use when                                 |
-|------------------|---------------------|------------------------------------------|
-| `"identity"`     | `I` (no covariance) | Isolating "warmup x0" from "warmup covariance" |
-| `"inverse"`      | `C⁻¹`               | Direction-corrected handoff (default)    |
-| `"sigma_inverse"`| `(σ²·C)⁻¹`          | Direction + scale, partially cancels σ collapse |
+| `HandoffTransform.` | `B₀` becomes        | Use when                                       |
+|---------------------|---------------------|------------------------------------------------|
+| `IDENTITY`          | `I` (no covariance) | Isolating "warmup x0" from "warmup covariance" |
+| `INVERSE`           | `C⁻¹`               | Direction-corrected handoff (default)          |
+| `SIGMA_INVERSE`     | `(σ²·C)⁻¹`          | Direction + scale, partially cancels σ collapse |
 
 Note: L-BFGS-B (bounded) maintains `B` (the Hessian), not `B⁻¹`. CMA-ES's
 covariance `C` is proportional to `B⁻¹`. Passing `C` directly is *wrong*
 (it tells L-BFGS-B that steep directions are flat). Empirical findings
-under `docs/covariance_handoff_when_it_matters.md`.
+under [`docs/covariance_handoff_when_it_matters.md`](docs/covariance_handoff_when_it_matters.md).
 
 ## API reference
 
@@ -484,6 +738,65 @@ class OptimizationResult(Generic[LogDataType]):
     algorithm: AlgorithmChoice
 ```
 
+### `BenchmarkAlgorithm`
+
+```python
+class BenchmarkAlgorithm(ABC):
+    name: str
+    color: str
+
+    @abstractmethod
+    def run(self, problem: Problem, x0: NDArray[np.float64], seed: int) -> RunTrace: ...
+
+    def trace_from_result(
+        self, problem: Problem, seed: int, result: OptimizationResult,
+    ) -> RunTrace
+```
+
+### `HandoffAlgorithm`
+
+```python
+class HandoffAlgorithm(BenchmarkAlgorithm):
+    @abstractmethod
+    def run_phases(
+        self, problem: Problem, x0: NDArray[np.float64], seed: int,
+    ) -> tuple[OptimizationResult, OptimizationResult]: ...
+
+    # run() and _stitch_traces() are inherited — eval-count offsets,
+    # fitness clamping, and handoff metadata are all handled by the base.
+```
+
+### `Panel` / `Series` / `PanelRegistry`
+
+```python
+@dataclass(frozen=True)
+class Series:
+    field: str
+    label: str = ""
+    linestyle: LineStyle | str = LineStyle.SOLID
+    color: str | None = None
+
+@dataclass(frozen=True)
+class Panel:
+    key: PanelKey | str
+    title: str
+    ylabel: str
+    field: str | None = None
+    series: tuple[Series, ...] | None = None
+    x_field: str = "evaluations"
+    yscale: YScale | str = YScale.LOG
+    floor: float | None = None
+    default: bool = True
+
+class PanelRegistry:
+    @classmethod def register(cls, algorithm: AlgorithmChoice, *panels: Panel) -> None
+    @classmethod def get(cls, algorithm: AlgorithmChoice, key: PanelKey | str) -> Panel
+    @classmethod def available(cls, algorithm: AlgorithmChoice) -> list[str]
+    @classmethod def default(cls, algorithm: AlgorithmChoice) -> list[str]
+    @classmethod def common(cls, algorithms: Sequence[AlgorithmChoice]) -> list[str]
+    @classmethod def all_registered(cls) -> dict[AlgorithmChoice, list[str]]
+```
+
 ### Enumerations
 
 ```python
@@ -510,9 +823,18 @@ class InitialHessianMode(Enum):
     DENSE = "dense"
 
 
-class InitialPointGeneratorType(Enum):
-    UNIFORM = "uniform"
-    NORMAL = "normal"
+class HandoffTransform(StrEnum):
+    INVERSE = "inverse"
+    SIGMA_INVERSE = "sigma_inverse"
+    IDENTITY = "identity"
+
+
+# Plotting StrEnums
+class PanelKey(StrEnum): ...  # See src/plotting/types.py for all values
+class YScale(StrEnum): LINEAR = "linear"; LOG = "log"
+class XAxis(StrEnum): EVALUATIONS = "evaluations"; ITERATION = "iteration"
+class LineStyle(StrEnum): SOLID = "-"; DASHED = "--"; DOTTED = ":"; DASH_DOT = "-."
+class PanelSet(StrEnum): DEFAULT = "default"; ALL = "all"
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -37,16 +37,19 @@ pdm run run-r            # CEC2017 F10, 10 seeds, writes CSVs for R cross-check
 Or directly:
 
 ```bash
-PYTHONPATH=. pdm run python -m experiments.basic.simple_optimization
+PYTHONPATH=. pdm run python experiments/basic/declarative_plotting.py
 PYTHONPATH=. pdm run python experiments/handoff/multimodal.py --num-seeds 25
 ```
 
 ## Minimal example
 
+Run one optimizer:
+
 ```python
 import numpy as np
 from src import AlgorithmFactory
 from src.algorithms.choices import AlgorithmChoice
+from src.plotting import plot_metrics
 from src.utils.benchmark_functions import Sphere
 
 func = Sphere(dimensions=10)
@@ -59,9 +62,36 @@ optimizer = AlgorithmFactory.create_optimizer(
     lower_bounds=-100,
     upper_bounds=100,
 )
-
 result = optimizer.optimize()
 print(f"f* = {result.best_fitness:.4e} after {result.evaluations} evals")
+
+plot_metrics(result, save_path="cmaes.png")  # every default panel for CMA-ES
+```
+
+Compare two algorithms:
+
+```python
+from src.plotting import plot_comparison
+
+plot_comparison(
+    {"CMA-ES": cmaes_result, "L-BFGS-B": lbfgsb_result},
+    save_path="comparison.png",
+)
+# Auto-picks the panels both algorithms expose (convergence + step_size by
+# default). CMA-ES sigma and L-BFGS-B step_length end up on the same axes
+# under one "Step Size" panel — semantic comparability is the point.
+```
+
+Multi-seed benchmark:
+
+```python
+from src.benchmarking import Benchmark, Problem, SingleAlgorithm, CMAESLBFGSBHandoff
+from src.plotting import plot_benchmark_convergence, plot_benchmark_boxplot
+
+bench = Benchmark(problems=[...], algorithms=[...], seeds=range(25), output_dir=...)
+bench.run()
+plot_benchmark_convergence(bench.traces, problems, algorithms, save_path="conv.png")
+plot_benchmark_boxplot   (bench.traces, problems, algorithms, save_path="box.png")
 ```
 
 See [`DOCUMENTATION.md`](DOCUMENTATION.md) for the full API.
@@ -73,13 +103,14 @@ declivity/
 ├── src/                          Library code (algorithms, framework)
 │   ├── core/                     BaseOptimizer, AlgorithmFactory, BaseConfig
 │   ├── algorithms/               DES, CMA-ES, MF-CMA-ES, L-BFGS-B
-│   ├── benchmarking/             Problem, AlgorithmRun, Benchmark, BenchmarkPlotter
+│   ├── benchmarking/             Problem, Benchmark, RunTrace
+│   │                             + BenchmarkAlgorithm / HandoffAlgorithm ABCs
 │   ├── utils/                    Benchmark functions, boundary handlers, helpers
-│   ├── logging/                  Per-algorithm diagnostic loggers
-│   └── plotting/                 Single-run multi-panel plots
+│   ├── logging/                  BaseLogData / PopulationLogData + per-algo loggers
+│   └── plotting/                 Declarative panel system (Panel + 8 entry points)
 │
 ├── experiments/                  Runnable studies (one script per study)
-│   ├── basic/                    Tutorial demos and sanity checks
+│   ├── basic/                    Tutorial demos, sanity checks, declarative API demos
 │   ├── cross_validation/         Cross-checks against R reference impls
 │   ├── lbfgsb/                   L-BFGS-B feature studies
 │   ├── handoff/                  CMA-ES → L-BFGS-B handoff studies
@@ -94,6 +125,7 @@ declivity/
 ## Where to look next
 
 - **API reference**: [`DOCUMENTATION.md`](DOCUMENTATION.md)
+- **Framework design principles**: [`docs/framework_design.md`](docs/framework_design.md)
 - **Experiment index**: [`experiments/README.md`](experiments/README.md)
 - **L-BFGS-B internals**: [`docs/lbfgsb_lecture.md`](docs/lbfgsb_lecture.md)
 - **Initial-Hessian design**: [`docs/lbfgsb_initial_hessian_design.md`](docs/lbfgsb_initial_hessian_design.md)

--- a/docs/framework_design.md
+++ b/docs/framework_design.md
@@ -1,0 +1,335 @@
+# Framework design
+
+The premises behind how the declivity framework is structured. Read this
+before adding a new algorithm, a new plotter primitive, a new extension
+point, or anything that changes the public API.
+
+The framework has two surface areas the user actually touches:
+
+1. **Optimizing** — running one or more optimizers on a problem.
+2. **Diagnosing** — looking at what they did.
+
+Most of the design effort goes into making (2) cheap. Optimization
+results that nobody can read aren't useful.
+
+---
+
+## Premise 1: Declarative > imperative for diagnostic plots
+
+A plotter that hardcodes "show CMA-ES like this, show DES like that"
+duplicates layout code per algorithm. Adding a new metric means editing
+the algorithm's bespoke plotting method. Comparing two algorithms means
+re-stating what's comparable each time.
+
+The framework's plotter avoids this by being **declarative**: you say
+what a panel is, the registry says what each algorithm exposes, and
+the rendering function reads both.
+
+### What a `Panel` describes
+
+```python
+Panel(
+    key=PanelKey.STEP_SIZE,   # semantic identifier
+    title="Step Size",
+    ylabel="σ",
+    field="sigma",            # attribute on the LogData
+    yscale=YScale.LOG,
+    floor=1e-30,              # log-scale safety
+    default=True,             # included in headline plot
+)
+```
+
+That's the whole vocabulary. No layout code, no subplot setup, no
+gridspec arithmetic. Adding a new panel for any algorithm is **one
+line in `src/plotting/standard_panels.py`**.
+
+### Why semantic keys are the load-bearing piece
+
+The same `PanelKey.STEP_SIZE` is registered with:
+
+- `field="sigma"` on CMA-ES
+- `field="Ft"` on DES
+- `field="step_length"` on L-BFGS-B
+
+`PanelRegistry.common([CMAES, DES, LBFGSB])` returns the keys
+registered for all three (`convergence`, `step_size`). `plot_comparison`
+defaults to that intersection: you ask to compare algorithms, the
+framework figures out what's comparable.
+
+Algorithm-specific fields keep their own keys (CMA-ES has
+`eigenvalue_max`, L-BFGS-B has `theta`). They're available via
+explicit selection, just not in the auto-intersection default.
+
+### Curated defaults vs. complete vocabulary
+
+`plot_metrics(result)` with no arguments renders panels marked
+`default=True`. That's the **headline** view — the panels that
+typically carry signal for that algorithm.
+
+Non-default panels stay registered (queryable via
+`PanelRegistry.available(...)`) but aren't in the default render.
+Users opt in with `panels=[PanelKey.WORST_FITNESS, ...]` or
+`panels=PanelSet.ALL`.
+
+Why this matters: registering everything means the registry is the
+single source of truth for "what diagnostics exist." Curated defaults
+mean the headline plot stays focused. Without the curation, CMA-ES's
+`plot_metrics` was producing 13-panel plots dominated by panels that
+never move (worst_fitness on CMA-ES is a near-constant).
+
+---
+
+## Premise 2: Progressive disclosure of extension points
+
+A user who needs to plug something into the benchmarking framework
+should encounter as little ceremony as possible. The framework
+provides four levels of structure, from concrete-and-easy to abstract-
+and-flexible:
+
+```
+BenchmarkAlgorithm (ABC)              — implement run() yourself
+├── SingleAlgorithm (concrete)        — wraps one optimizer
+└── HandoffAlgorithm (ABC)            — implement run_phases()
+    └── CMAESLBFGSBHandoff (concrete) — pre-built handoff
+```
+
+And, for the case where inheritance isn't viable, the
+`AlgorithmRun` Protocol — duck-typed, three attributes (`name`,
+`color`, `run()`).
+
+### How to pick which level
+
+| Your runner is... | Inherit from | What you write |
+|---|---|---|
+| one optimizer | `SingleAlgorithm` | nothing — just instantiate it |
+| warmup → refinement | `HandoffAlgorithm` | `run_phases()` returning `(warmup, refinement)` |
+| anything else | `BenchmarkAlgorithm` | `run()` returning a `RunTrace` |
+| can't inherit | `AlgorithmRun` Protocol | conform structurally |
+
+### Why subclass instead of compose
+
+Each level adds **shared boilerplate**. `BenchmarkAlgorithm` provides
+`trace_from_result()` that packages a single `OptimizationResult` into a
+`RunTrace`. `HandoffAlgorithm` provides `_stitch_traces()` that handles
+eval-count offsets, fitness clamping, and handoff metadata. Subclasses
+get those for free and only describe what's algorithm-specific.
+
+When `CMAESLBFGSBHandoff` was refactored to subclass `HandoffAlgorithm`,
+~40 lines of trace-stitching boilerplate disappeared from the class.
+The remaining ~50 lines are *only* about the CMA-ES covariance
+transformation — which is the actually-interesting bit.
+
+### Validation via existing code
+
+A good abstraction makes existing code shorter. The
+`HandoffAlgorithm` extraction was validated by re-fitting
+`CMAESLBFGSBHandoff` onto it: if the existing pre-built class doesn't
+fit, the abstraction is wrong.
+
+---
+
+## Premise 3: Backwards-compatible vocabulary via StrEnum
+
+Public-facing strings (`"inverse"` for handoff transform,
+`"convergence"` for panel keys, `"log"` for yscale) get autocomplete
+and refactor safety as `StrEnum` types. A `StrEnum` member compares
+equal to its value, so:
+
+```python
+plot_metrics(result, panels=["convergence", "step_size"])      # works
+plot_metrics(result, panels=[PanelKey.CONVERGENCE, PanelKey.STEP_SIZE])  # also works
+```
+
+The framework normalizes via `str(...)` internally so the registry
+sees the same key regardless of how it was passed.
+
+Why this matters: when the framework added enums, the entire existing
+test/experiment base kept working without a single line change. A
+breaking enum migration would have been the kind of change that
+silently rots in unmaintained corners of a thesis project.
+
+---
+
+## Premise 4: Layered LogData by capability
+
+The framework's optimizers don't all produce the same diagnostic
+fields. L-BFGS-B is a single-point method — there's no "population
+mean fitness" to log. Putting all fields on a single `BaseLogData`
+forced LBFGSB to inherit empty lists for fields it never used.
+
+The fix:
+
+```
+BaseLogData                  — iteration, evaluations, best_fitness, best_solution
+└── PopulationLogData        — adds worst/mean/std/population/eigenvalues
+```
+
+Single-point algorithms inherit `BaseLogData` directly. Population-
+based algorithms (DES, CMA-ES, MF-CMA-ES) inherit `PopulationLogData`.
+
+The plotter uses `getattr(log_data, field, None)` so missing fields
+just produce empty plots — no exceptions, no special-casing per
+algorithm. That tolerance + the layered hierarchy means a user who
+writes a new single-point algorithm only inherits fields they'll
+actually populate.
+
+---
+
+## Premise 5: Trace stitching is the base class's job
+
+A handoff algorithm runs two optimizers and concatenates their results
+into a single convergence trace. That concatenation has subtle bits:
+
+- The refinement's evaluation counter starts at 0; it needs to be
+  offset by the warmup's total.
+- The refinement's logged "best fitness" starts at `f(x0_refinement)`,
+  which might be slightly worse than the warmup's running best. Without
+  clamping, the convergence trace goes *up* at the handoff point.
+- The plotter wants a `handoff_eval` annotation, and an optional
+  `handoff_iter` annotation for iteration-axis plots.
+
+`HandoffAlgorithm._stitch_traces()` handles all three. Subclasses
+return `(warmup_result, refinement_result)` and never touch the
+arithmetic. That keeps the interesting algorithmic work (e.g. the
+covariance transformation in `CMAESLBFGSBHandoff`) un-tangled from the
+bookkeeping.
+
+---
+
+## Premise 6: Diagnostics opt-in, not opt-out
+
+Every algorithm always logs the universal trace fields (iteration,
+evaluations, best_fitness, best_solution). Population, eigenvalues,
+detailed gradient norms, etc. are gated by `diag_*` flags on the
+config because they're memory- or compute-expensive.
+
+The flag set is intentionally **lean**: a flag exists only when an
+optimizer or logger actually gates behavior on it. During the
+refactor, six dead flags were removed from `BaseConfig` (`diag_enabled`,
+`diag_value`, `diag_mean`, `diag_meanCords`, `diag_worstVal`,
+`diag_bestVal`) plus algorithm-specific dead flags
+(`CMAESConfig.diag_cond`, `MFCMAESConfig.diag_archive`).
+
+The principle: **a config field that toggles nothing is misleading,
+not flexible**. Users will spend time setting it expecting an effect.
+Remove it.
+
+---
+
+## Premise 7: Same seed ⇒ same starting point
+
+The framework guarantees that running multiple algorithms with the
+same seed gives them the same initial point. `Problem.starting_point(seed)`
+is deterministic. This means:
+
+- A standalone CMA-ES run and a `CMAESLBFGSBHandoff` run with the same
+  seed share the entire CMA-ES warmup trace exactly.
+- A side-by-side comparison plot reflects *only* the algorithm
+  differences, not random variation in starting points.
+
+The `RunTrace.seed` field is the load-bearing piece: persistence,
+re-plotting, and statistical aggregation all hinge on it.
+
+---
+
+## Premise 8: `RunTrace` as the persistence boundary
+
+Multi-seed benchmarks can produce gigabytes of `LogData` if every seed
+keeps the full population history. The framework distinguishes:
+
+- **`OptimizationResult` (in-memory)** — full LogData, single run.
+- **`RunTrace` (persisted)** — just `evaluations` + `best_fitness` +
+  final stats + handoff metadata.
+
+`Benchmark.run()` consumes `OptimizationResult`s, throws away the
+diagnostic detail, and persists `RunTrace`s. The resulting `traces.json`
+is small enough to commit (when you want to) and lets you re-plot
+without re-running.
+
+If you ever need richer multi-seed diagnostics, **extend `RunTrace`**.
+Don't bypass it by trying to keep full LogData lists per seed.
+
+---
+
+## How the design got here (iteration log)
+
+The framework wasn't designed top-down. The current shape emerged by
+iterating on review feedback:
+
+1. **Initial review.** Audit found the old `MultiAlgorithmPlotter`
+   had a 100-line `_plot_<algo>_metrics` method for each algorithm,
+   duplicating layout boilerplate four times. The benchmarking layer
+   had a separate `BenchmarkPlotter` that didn't share any code with
+   it. Adding a panel meant editing the algorithm's method.
+
+2. **Declarative panel system.** First pass: `Panel` + `PanelRegistry`
+   + `plot_metrics` + `plot_comparison`. Cross-algorithm semantic keys
+   from the start. Multi-seed left for later.
+
+3. **Multi-seed declarative functions.** `plot_benchmark_convergence`
+   and `plot_benchmark_boxplot` as module functions, reusing the
+   existing aggregation helpers. Verified pixel-for-pixel match against
+   the legacy `BenchmarkPlotter` on the multimodal benchmark.
+
+4. **Migration of two flagship experiments.** Sanity check: do the
+   new plots produce the same insights as the old?
+
+5. **Side-by-side review of `_plot_cmaes_metrics`.** Three regressions
+   noticed:
+   - 13 panels vs. legacy 8 (too noisy).
+   - Multi-series convergence (best+mean+median on one axes) gone.
+   - "Worst Fitness on CMA-ES" panel rendering essentially flat noise.
+
+   Fix: added `Series` + `default=bool` to `Panel`. Curated default
+   subsets per algorithm. Multi-series for the convergence panel.
+
+6. **StrEnum vocabulary.** Realized every public string had a finite
+   set of values. `PanelKey`, `YScale`, `XAxis`, `LineStyle`, `PanelSet`.
+   Backwards-compatible because `StrEnum` members are strings.
+
+7. **`HandoffAlgorithm` extraction.** The custom-handoff demo
+   (DES → L-BFGS-B) duplicated ~40 lines of trace stitching from the
+   pre-built `CMAESLBFGSBHandoff`. Extracted the boilerplate into a
+   `HandoffAlgorithm` ABC. Validated by re-fitting `CMAESLBFGSBHandoff`
+   onto it — the refactor dropped ~40 lines from the pre-built class.
+
+8. **`BenchmarkAlgorithm` extraction.** Same pattern one level up.
+   `SingleAlgorithm` and `HandoffAlgorithm` both had `trace_from_result`-
+   shaped helpers; extracted into a common `BenchmarkAlgorithm` ABC.
+   Now any custom benchmark runner picks the level of structure it
+   wants.
+
+9. **`BaseLogData` split + diag flag prune.** Cleanup pass: removed
+   the dead diag flags (six on `BaseConfig`, two algorithm-specific),
+   split `BaseLogData` so single-point methods don't inherit empty
+   population fields.
+
+10. **All experiments migrated, legacy plotters deleted.** −1409 lines
+    of legacy plotting code removed.
+
+The pattern through all of this: **extract abstractions only after the
+duplication makes them obvious**. Each extraction (`Panel`,
+`HandoffAlgorithm`, `BenchmarkAlgorithm`) was preceded by writing the
+same boilerplate twice (or finding it already written four times in
+the old code).
+
+---
+
+## What we *didn't* do
+
+A few things were deliberately left as deferred work:
+
+- **Extending `RunTrace`** with per-seed diagnostic fields (so
+  multi-seed plots could show e.g. step-size bands across algorithms).
+  Doable, but expands persistence scope significantly.
+- **Generalizing `HandoffAlgorithm` to N phases.** Two-phase covers
+  every current use case; three-phase would be over-engineering until
+  a real example shows up.
+- **`MultiPhaseAlgorithm` as an explicit base class.** A three-phase
+  algorithm today implements `BenchmarkAlgorithm.run()` directly. If
+  three-phase becomes common, extract a base class then, not now.
+- **Removing the `cmaes_reference.py` port.** It's still used as a
+  verification reference against `cmaes_optimizer.py`. Keep it.
+
+The point of leaving them: **abstractions extracted before you have
+the duplication are usually wrong**.

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -23,8 +23,12 @@ pdm run run-r            # experiments/cross_validation/des_vs_r.py
 
 | Script                       | What it does                                                    | Output                                  |
 |------------------------------|-----------------------------------------------------------------|-----------------------------------------|
-| `simple_optimization.py`     | DES on a 10D Sphere; smallest end-to-end demo                  | `plots/basic/simple_optimization/`      |
+| `simple_optimization.py`     | Runs every algorithm on a 10D Sphere and dumps each one's default diagnostic-panel view | `plots/basic/simple_optimization/`      |
 | `covariance_adaptation.py`   | CMA-ES on Sphere / Ellipsoid; visualizes empirical covariance evolution (eigenvalues, condition, 2D ellipse snapshots) | `plots/basic/covariance_adaptation/`    |
+| `declarative_plotting.py`    | End-to-end demo of `plot_metrics` and `plot_comparison` — including `PanelRegistry.common([algos])` introspection | `plots/basic/declarative_plotting/`     |
+| `declarative_benchmark.py`   | End-to-end demo of `plot_benchmark_convergence` and `plot_benchmark_boxplot` with a real CMA-ES → L-BFGS-B handoff | `plots/basic/declarative_benchmark/`    |
+| `custom_handoff.py`          | Builds a DES → L-BFGS-B handoff from scratch by subclassing `HandoffAlgorithm` (one `run_phases()` method) | `plots/basic/custom_handoff/`           |
+| `custom_algorithm.py`        | Multi-start CMA-ES via `BenchmarkAlgorithm` directly; shows the generic extension point | `plots/basic/custom_algorithm/`         |
 
 ## `cross_validation/` — checks against external references
 
@@ -38,7 +42,7 @@ pdm run run-r            # experiments/cross_validation/des_vs_r.py
 |----------------------|-------------------------------------------------------------------------------------------|-------------------------------------|
 | `sphere_benchmark.py`| L-BFGS-B (More-Thuente and Armijo) vs CMA-ES on 10D Sphere                                | `plots/lbfgsb/sphere_benchmark/`    |
 | `initial_hessian.py` | Effect of `initial_hessian` and `persist_initial_hessian` on 10D Ellipsoid (cond 10⁶)     | `plots/lbfgsb/initial_hessian/`     |
-| `rotation_study.py`  | Full-Hessian vs diagonal vs identity B₀ across 4 rotations × {n=10,m=10}, {n=50,m=5}     | `plots/lbfgsb/rotation_study/`      |
+| `rotation_study.py`  | Full-Hessian vs diagonal vs identity B₀ across 4 rotations × {n=10,m=10}, {n=50,m=5}; also produces landscape grids | `plots/lbfgsb/rotation_study/`      |
 
 ## `handoff/` — CMA-ES → L-BFGS-B handoff studies
 
@@ -54,7 +58,6 @@ covariance to L-BFGS-B as the initial Hessian B₀.
 | `timing_sweep_multimodal.py`    | Multimodal warmup sweep: 5 handoff timings × CMA-ES + L-BFGS-B baselines                                     | `plots/handoff/timing_sweep_multimodal/`          |
 | `timing_sweep_rippled.py`       | Rippled-ellipsoid warmup sweep; demonstrates the non-monotone sweet spot                                     | `plots/handoff/timing_sweep_rippled/`             |
 | `timing_sweep_families.py`      | Parameterized timing sweep across 4 named experimental families (`baseline`, `reproduce_old`, `low_amp`, `multimodal`) | `plots/report/timing_{family}/`                   |
-| `_legacy_cmaes_to_lbfgsb.py`    | Earlier handoff prototype; reaches into private CMA-ES attributes. Kept for archival; use the others instead | `plots/handoff/_legacy/`                          |
 
 Common flags (most scripts): `--num-seeds`, `--num-workers`,
 `--total-budget`, `--cmaes-warmup-budget`, `--dimensions`,
@@ -75,4 +78,13 @@ Common flags (most scripts): `--num-seeds`, `--num-workers`,
 3. If the experiment uses the multi-seed framework, prefer
    `src.benchmarking.Benchmark` — you get persisted `traces.json` for
    free, which makes the result re-plottable without re-running.
-4. Document it in this README.
+4. For plotting, use the declarative API in `src.plotting`:
+   - `plot_metrics(result)` for single-run diagnostics.
+   - `plot_comparison(results)` for cross-algorithm comparison.
+   - `plot_benchmark_convergence(...)` / `plot_benchmark_boxplot(...)`
+     for multi-seed benchmark plots.
+5. If you need a custom benchmark runner (something `SingleAlgorithm`
+   doesn't cover), inherit from `BenchmarkAlgorithm` (or
+   `HandoffAlgorithm` for two-phase runners). See `basic/custom_handoff.py`
+   and `basic/custom_algorithm.py` for examples.
+6. Document it in this README.


### PR DESCRIPTION
## Summary

Brings the documentation in sync with the refactor that landed in #12 and #13.

- **README.md** — quick-start now uses \`plot_metrics\` / \`plot_comparison\` /
  benchmark plotting; updated project layout; new where-to-look-next entry
  pointing at the design doc.

- **DOCUMENTATION.md** — major rewrite of the plotting, logging, and
  benchmarking sections. New \`Panel\` / \`PanelRegistry\` API reference.
  \`BenchmarkAlgorithm\` + \`HandoffAlgorithm\` documented. All legacy plotter
  references removed.

- **experiments/README.md** — new \`basic/\` entries for the four new demo
  files (\`declarative_plotting\`, \`declarative_benchmark\`, \`custom_handoff\`,
  \`custom_algorithm\`). Removed the \`_legacy\` entry. Updated the
  \"adding a new experiment\" guidance to point at the declarative plotter
  and the \`BenchmarkAlgorithm\` extension points.

- **docs/framework_design.md** (new) — standalone write-up of the design
  premises that shaped the current API:

  1. Declarative > imperative for diagnostic plots
  2. Semantic keys cross algorithms (\`PanelKey.STEP_SIZE\` → sigma/Ft/step_length)
  3. Progressive disclosure of extension points (4 levels of structure)
  4. \`StrEnum\` for backwards-compatible vocabulary
  5. Layered LogData by capability (\`BaseLogData\` vs \`PopulationLogData\`)
  6. Trace stitching is base-class work
  7. Diagnostics opt-in; dead flags removed
  8. Same seed → same starting point
  9. \`RunTrace\` as the persistence boundary
  10. Curated defaults, complete vocabulary

  Plus the meta-premise: **abstractions extracted only after the
  duplication makes them obvious**.

  Includes a chronological iteration log of how the current shape
  emerged from session-by-session review feedback — useful for future
  framework work so the rationale doesn't get re-derived.

## Test plan

- [x] Markdown renders correctly (no broken links to deleted files)
- [x] Code snippets in \`README.md\` and \`DOCUMENTATION.md\` import from
  the current \`src.plotting\` and \`src.benchmarking\` API
- [x] Cross-links between docs resolve