### PR TITLE
Fix audit findings across all optimizer implementations

### DIFF
--- a/declivity/algorithms/cmaes/cmaes_optimizer.py
+++ b/declivity/algorithms/cmaes/cmaes_optimizer.py
@@ -105,7 +105,7 @@ class CMAESOptimizer(PopulationOptimizer["CMAESLogData", CMAESConfig]):
     population is produced by the injected
     :class:`~src.utils.population_initializers.PopulationInitializer`
     (default: :class:`~src.utils.population_initializers.MeanSigmaPopulationInitializer`
-    with ``sigma=config.sigma``, which reproduces the canonical
+    with the resolved initial sigma, which reproduces the canonical
     ``N(m, σ²I)`` start).  Both seams are live — swapping the defaults
     changes the algorithm's behaviour.
     """
@@ -129,10 +129,13 @@ class CMAESOptimizer(PopulationOptimizer["CMAESLogData", CMAESConfig]):
 
         # Resolve auto-sigma (config.sigma == 0.0) up-front so the default
         # population_initializer can be constructed with the final value.
-        if config.sigma == 0.0:
+        # The resolution stays local — the caller's config is never mutated,
+        # so one config can be reused across optimizers with different bounds.
+        initial_sigma = float(config.sigma)
+        if initial_sigma == 0.0:
             lb_array = BaseOptimizer._process_bounds(lower_bounds, len(initial_point))
             ub_array = BaseOptimizer._process_bounds(upper_bounds, len(initial_point))
-            config.sigma = float(np.mean(ub_array - lb_array) / 5.0)
+            initial_sigma = float(np.mean(ub_array - lb_array) / 5.0)
 
         super().__init__(
             func=func,
@@ -141,7 +144,7 @@ class CMAESOptimizer(PopulationOptimizer["CMAESLogData", CMAESConfig]):
             repair_strategy=repair_strategy or LamarckianRepair(),
             population_initializer=(
                 population_initializer
-                or MeanSigmaPopulationInitializer(sigma=config.sigma)
+                or MeanSigmaPopulationInitializer(sigma=initial_sigma)
             ),
             algorithm=AlgorithmChoice.CMAES,
             constraint_handler=constraint_handler,
@@ -153,7 +156,14 @@ class CMAESOptimizer(PopulationOptimizer["CMAESLogData", CMAESConfig]):
 
         n = self.dimensions
         self._mean: NDArray[np.float64] = self.initial_point.copy()
-        self._sigma: float = float(self.config.sigma)
+        self._initial_sigma: float = initial_sigma
+        self._sigma: float = initial_sigma
+        # config.tolx is derived from config.sigma; when auto-sigma resolved
+        # locally (config.sigma == 0.0 → config.tolx == 0.0), re-derive it
+        # from the resolved value instead of writing back into the config.
+        self._tolx: float = (
+            self.config.tolx if self.config.sigma != 0.0 else 1e-12 * initial_sigma
+        )
         self._C: NDArray[np.float64] = np.eye(n)
         self._pc: NDArray[np.float64] = np.zeros(n)
         self._p_sigma: NDArray[np.float64] = np.zeros(n)
@@ -163,6 +173,10 @@ class CMAESOptimizer(PopulationOptimizer["CMAESLogData", CMAESConfig]):
         self._generation = 0
         self._funhist_values = np.full(self.config.funhist_term * 2, np.inf)
 
+        # With a restored state, generation-0 sampling must honour the
+        # restored sigma/covariance instead of the construction-time
+        # PopulationInitializer (see _generate_population).
+        self._restored_from_state = initial_state is not None
         if initial_state is not None:
             self._apply_state(initial_state)
 
@@ -242,7 +256,6 @@ class CMAESOptimizer(PopulationOptimizer["CMAESLogData", CMAESConfig]):
         self._begin_run()
         best_fitness = float("inf")
         best_solution = self._mean.copy()
-        worst_fitness: float | None = None
         message: str | None = None
 
         lambda_ = self.config.population_size
@@ -263,10 +276,13 @@ class CMAESOptimizer(PopulationOptimizer["CMAESLogData", CMAESConfig]):
                     best_solution = population[k].copy()
 
             # ---- Bookkeeping for the iteration log -----------------------
-            iter_worst = float(np.max(fitness_values))
-            worst_fitness = iter_worst if worst_fitness is None else max(worst_fitness, iter_worst)
+            worst_fitness = float(np.max(fitness_values))
             median_fitness = float(np.median(fitness_values))
-            mean_fitness_value = self.evaluate(self.constraint_handler.repair(self._mean))
+            repaired_mean = self.constraint_handler.repair(self._mean)
+            mean_fitness_value = self.evaluate(repaired_mean)
+            if mean_fitness_value < best_fitness:
+                best_fitness = float(mean_fitness_value)
+                best_solution = repaired_mean.copy()
 
             # ---- Update distribution -------------------------------------
             self._tell(population, fitness_values)
@@ -282,7 +298,7 @@ class CMAESOptimizer(PopulationOptimizer["CMAESLogData", CMAESConfig]):
                 fitness=fitness_values,
                 population=population if self.config.diag_pop else None,
                 best_fitness=best_fitness,
-                worst_fitness=worst_fitness if worst_fitness is not None else float("inf"),
+                worst_fitness=worst_fitness,
                 best_solution=best_solution,
                 mean_fitness=mean_fitness_value,
                 median_fitness=median_fitness,
@@ -317,14 +333,16 @@ class CMAESOptimizer(PopulationOptimizer["CMAESLogData", CMAESConfig]):
     def _generate_population(self, lambda_: int) -> NDArray[np.float64]:
         """Produce the λ candidates for the current generation.
 
-        Iteration 0 routes through the injected
+        Iteration 0 of a fresh run routes through the injected
         :class:`PopulationInitializer` so the initial sampling shape is
-        swappable.  Subsequent iterations sample from ``N(m, σ²C)`` using
-        the algorithm's current eigendecomposition — there is no
-        framework primitive that owns the correlated covariance, so this
-        stays internal.
+        swappable.  Subsequent iterations — and every iteration of a run
+        restored from a :class:`CMAESState` (whose sigma/covariance must
+        be honoured even at ``generation == 0``) — sample from
+        ``N(m, σ²C)`` using the algorithm's current eigendecomposition —
+        there is no framework primitive that owns the correlated
+        covariance, so this stays internal.
         """
-        if self._generation == 0:
+        if self._generation == 0 and not self._restored_from_state:
             return self.population_initializer.generate_population(
                 rng=self.rng,
                 x0=self._mean,
@@ -469,7 +487,7 @@ class CMAESOptimizer(PopulationOptimizer["CMAESLogData", CMAESConfig]):
         ):
             return "Function value range below tolerance."
 
-        if np.all(sigma * dC < cfg.tolx) and np.all(sigma * self._pc < cfg.tolx):
+        if np.all(sigma * dC < self._tolx) and np.all(sigma * self._pc < self._tolx):
             return "All standard deviations smaller than tolerance."
 
         if sigma * float(np.max(D)) > cfg.tolxup:

--- a/declivity/algorithms/cmaes/config.py
+++ b/declivity/algorithms/cmaes/config.py
@@ -98,9 +98,6 @@ class CMAESConfig(PopulationBaseConfig):
     population_size: int = field(default=0)
     """Population size λ (``0`` → default ``4 + ⌊3 ln d⌋``)."""
 
-    diag_sigma: bool = False
-    """Log σ every generation."""
-
     diag_covariance_matrix: bool = False
     """Store the full covariance matrix every generation (memory-heavy)."""
 
@@ -155,7 +152,6 @@ class CMAESConfig(PopulationBaseConfig):
 
     def enable_all_diagnostics(self) -> None:
         super().enable_all_diagnostics()
-        self.diag_sigma = True
         self.diag_covariance_matrix = True
 
     def __str__(self) -> str:

--- a/declivity/algorithms/des/config.py
+++ b/declivity/algorithms/des/config.py
@@ -51,26 +51,12 @@ def default_pathratio(obj: "DESConfig") -> float:
     return np.sqrt(obj.path_length)
 
 
-def default_ft_scale(obj: "DESConfig") -> float:
-    """Default Ft scaling factor."""
-    N = obj.dimensions
-    mu_eff = obj.mu_eff
-    return ((mu_eff + 2) / (N + mu_eff + 3)) / (
-        1
-        + 2 * max(0, np.sqrt((mu_eff - 1) / (N + 1)) - 1)
-        + (mu_eff + 2) / (N + mu_eff + 3)
-    )
-
-
 @dataclass
 class DESConfig(PopulationBaseConfig):
     """
     Configuration for the DES optimizer.
     Extends PopulationBaseConfig with DES-specific parameters.
     """
-
-    ft: float = 1.0
-    """Scaling factor of difference vectors"""
 
     init_ft: float = 1.0
     """Initial scaling factor"""
@@ -99,10 +85,6 @@ class DESConfig(PopulationBaseConfig):
     lamarckian: bool = False
     """Whether to use Lamarckian evolution"""
 
-    # DES-specific diagnostic logging
-    diag_ft: bool = False
-    """Log Ft values"""
-
     # Computed/derived parameters
     cp: float = field(init=False)
     """Evolution path decay factor"""
@@ -128,9 +110,6 @@ class DESConfig(PopulationBaseConfig):
     mu_eff: float = field(init=False)
     """Effective selection mass"""
 
-    ft_scale: float = field(init=False)
-    """Scaling factor for Ft"""
-
     def __post_init__(self) -> None:
         """Calculate derived parameters that depend on other params"""
         if self.population_size <= 0:
@@ -147,21 +126,13 @@ class DESConfig(PopulationBaseConfig):
         weights_sum_square = np.sum(self.weights**2)
         self.mu_eff = np.sum(self.weights) ** 2 / weights_sum_square
 
-        self.ft_scale = default_ft_scale(self)
-
         super().validate()
-
-    def enable_all_diagnostics(self) -> None:
-        """Enable all diagnostic logging options including DES-specific ones."""
-        super().enable_all_diagnostics()
-        self.diag_ft = True
 
     def __str__(self) -> str:
         """String representation of the DESConfig."""
         return (
             f"DESConfig(dimensions={self.dimensions}, "
-            f"population_size={self.population_size}, ft={self.ft}, "
+            f"population_size={self.population_size}, "
             f"init_ft={self.init_ft}, path_length={self.path_length}, "
-            f"c_ft={self.c_ft}, lamarckian={self.lamarckian}, "
-            f"diag_ft={self.diag_ft})"
+            f"c_ft={self.c_ft}, lamarckian={self.lamarckian})"
         )

--- a/declivity/algorithms/des/des_optimizer.py
+++ b/declivity/algorithms/des/des_optimizer.py
@@ -1,7 +1,6 @@
 from collections import deque
 from typing import Callable, final, Union, TYPE_CHECKING
 import numpy as np
-import math
 from numpy.typing import NDArray
 from scipy.special import gamma
 from declivity.algorithms.choices import AlgorithmChoice
@@ -79,10 +78,12 @@ class DESOptimizer(PopulationOptimizer[DESLogData, DESConfig]):
         best_fitness = float("inf")
         best_solution = self.initial_point.copy()
         worst_fitness = None
-        message = None
         iter_count = 0
 
-        hist_head = 0
+        # Matches DES.R: histHead starts one slot before the first write
+        # and is advanced at the top of every iteration, so iteration 1
+        # writes slot 0.
+        hist_head = -1
         history: list[NDArray[np.float64]] = []
         ft = init_ft
 
@@ -106,6 +107,16 @@ class DESOptimizer(PopulationOptimizer[DESLogData, DESConfig]):
         fitness = self.evaluate_population(
             population if lamarckian else population_repaired
         )
+
+        # Track the best of the initial population.  This feeds only
+        # logging, should_stop, and the result — not the sampling math.
+        finite = np.isfinite(fitness)
+        if np.any(finite):
+            init_best = int(np.argmin(np.where(finite, fitness, np.inf)))
+            best_fitness = float(fitness[init_best])
+            best_solution = (
+                population if lamarckian else population_repaired
+            )[init_best].copy()
 
         old_mean = np.zeros(N)
         # Matches DES.R line 215: ``newMean <- par`` — the algorithm
@@ -138,10 +149,6 @@ class DESOptimizer(PopulationOptimizer[DESLogData, DESConfig]):
             iter_count += 1
             hist_head = (hist_head + 1) % hist_size
 
-            mu = math.floor(lambda_ / 2)
-            weights = np.log(mu + 1) - np.log(np.arange(1, mu + 1))
-            weights = weights / np.sum(weights)
-
             self.logger.log_iteration(
                 iteration=iter_count,
                 evaluations=self.evaluations,
@@ -154,8 +161,12 @@ class DESOptimizer(PopulationOptimizer[DESLogData, DESConfig]):
                 ),
                 best_solution=best_solution,
                 mean_fitness=float(np.mean(fitness)),
+                # pc[:, hist_head] is written later this iteration; the
+                # freshest column is the previous slot (negative index
+                # wraps the ring, zeros before the first write).
+                evolution_path=pc[:, hist_head - 1].copy(),
                 eigenvalues=(
-                    np.sort(np.linalg.eigvals(np.cov(population.T)))[::-1]
+                    np.linalg.eigvalsh(np.cov(population.T))[::-1]
                     if self.config.diag_eigen
                     else None
                 ),
@@ -166,7 +177,7 @@ class DESOptimizer(PopulationOptimizer[DESLogData, DESConfig]):
             selected_points = population[selection]
 
             # Save selected population in history buffer
-            if len(history) < hist_size:
+            if len(history) <= hist_head:
                 history.append(selected_points.T * hist_norm / ft)
             else:
                 history[hist_head] = selected_points.T * hist_norm / ft
@@ -212,7 +223,9 @@ class DESOptimizer(PopulationOptimizer[DESLogData, DESConfig]):
                     mu * cp * (2 - cp)
                 ) * step
 
-            # Sample from history
+            # Sample from history — equals the reference's
+            # ``histHead + 1 if iter < histSize else histSize`` since
+            # hist_head == (iter_count - 1) % hist_size.
             limit = min(iter_count, hist_size)
             history_sample = self.rng.choice(limit, lambda_, replace=True)
             history_sample2 = self.rng.choice(limit, lambda_, replace=True)
@@ -276,31 +289,31 @@ class DESOptimizer(PopulationOptimizer[DESLogData, DESConfig]):
                     population_repaired[best_idx]
                     if not lamarckian
                     else population[best_idx]
-                )
+                ).copy()
 
             # Check worst fitness
             worst_idx = np.argmax(fitness)
-            if (
-                fitness[worst_idx] > worst_fitness
-                if worst_fitness is not None
-                else float("-inf")
+            if fitness[worst_idx] > (
+                worst_fitness if worst_fitness is not None else float("-inf")
             ):
                 worst_fitness = fitness[worst_idx]
 
-            # Check if the mean point is better
+            # Check if the mean point is better — skipped when a hard
+            # evaluation cap is already exhausted.
             cumulative_mean = 0.8 * cumulative_mean + 0.2 * new_mean
             cumulative_mean_repaired = self.constraint_handler.repair(cumulative_mean)
-            mean_fitness = self.evaluate(cumulative_mean_repaired)
-
-            if mean_fitness < best_fitness:
-                best_fitness = mean_fitness
-                best_solution = cumulative_mean_repaired
+            remaining = self.stopping_condition.remaining_evaluations(self.evaluations)
+            if remaining is None or remaining > 0:
+                mean_fitness = self.evaluate(cumulative_mean_repaired)
+                if mean_fitness < best_fitness:
+                    best_fitness = mean_fitness
+                    best_solution = cumulative_mean_repaired.copy()
 
         result: OptimizationResult[DESLogData] = OptimizationResult(
             best_solution=best_solution,
             best_fitness=best_fitness,
             evaluations=self.evaluations,
-            message=message if message else self.stop_message,
+            message=self.stop_message,
             diagnostic=self.get_logs(),
             algorithm=AlgorithmChoice.DES,
         )

--- a/declivity/algorithms/lbfgsb/config.py
+++ b/declivity/algorithms/lbfgsb/config.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Union
 import numpy as np
 from numpy.typing import NDArray
@@ -59,14 +59,19 @@ class LBFGSBConfig(BaseConfig):
     if the interval of uncertainty is within xtol_ls of the current step."""
 
     max_ls_iter: int = 20
-    """Maximum number of function evaluations per line search call."""
+    """Maximum number of trial steps per line search call. Each trial costs
+    one or more function evaluations depending on the injected line search
+    and gradient mode (e.g., 3 per trial for More-Thuente in central-FD mode,
+    1 per trial for Armijo backtracking)."""
 
     fd_eps: float = 0.0
     """Finite-difference step size used by both the gradient strategy
-    and the optimizer's directional-derivative computation.  0 = auto
-    (``sqrt(machine_eps)`` — appropriate for the default ``CentralFD``).
-    Override per-strategy via the ``gradient_strategy`` ctor parameter
-    if a different step is needed (e.g., for ``ForwardFD``)."""
+    and the optimizer's directional-derivative computation.  0 = auto:
+    the optimizer resolves a strategy-appropriate step at construction —
+    ``machine_eps**(1/3)`` (~6e-6) for the default ``CentralFD``, whose
+    truncation/rounding trade-off is optimal at ``eps**(1/3)``, and
+    ``sqrt(machine_eps)`` (~1.5e-8) for ``ForwardFD``.  Explicit positive
+    values are passed through untouched."""
 
     # Diagnostic flags specific to L-BFGS-B
     diag_gradient_norm: bool = False
@@ -84,20 +89,7 @@ class LBFGSBConfig(BaseConfig):
     diag_line_search_iters: bool = False
     """Log number of line search function evaluations each iteration."""
 
-    # Derived parameters
-    _fd_eps_actual: float = field(init=False, repr=False)
-    """Actual finite difference epsilon (computed from fd_eps)."""
-
     def __post_init__(self) -> None:
-        self._recalculate_derived_params()
-
-    def _recalculate_derived_params(self) -> None:
-        eps = np.finfo(float).eps
-        if self.fd_eps <= 0:
-            self._fd_eps_actual = eps**0.5
-        else:
-            self._fd_eps_actual = self.fd_eps
-
         self.validate()
 
     def validate(self) -> None:
@@ -109,11 +101,6 @@ class LBFGSBConfig(BaseConfig):
             raise ValueError("factr must be non-negative.")
         if self.pgtol < 0:
             raise ValueError("pgtol must be non-negative.")
-
-    def __setattr__(self, name: str, value) -> None:
-        super().__setattr__(name, value)
-        if name == "fd_eps" and hasattr(self, "_fd_eps_actual"):
-            self._recalculate_derived_params()
 
     def enable_all_diagnostics(self) -> None:
         super().enable_all_diagnostics()

--- a/declivity/algorithms/lbfgsb/lbfgsb_optimizer.py
+++ b/declivity/algorithms/lbfgsb/lbfgsb_optimizer.py
@@ -31,7 +31,7 @@ from declivity.utils.line_search import (
     MoreThuenteLineSearch,
 )
 from declivity.utils.constraint_handlers import ConstraintHandler
-from declivity.utils.gradient_strategies import CentralFD, GradientStrategy
+from declivity.utils.gradient_strategies import CentralFD, ForwardFD, GradientStrategy
 from declivity.utils.stopping_conditions import StoppingCondition
 from declivity.core.base_optimizer import BaseOptimizer, OptimizationResult
 from declivity.core.algorithm_factory import register_optimizer
@@ -83,16 +83,32 @@ class LBFGSBOptimizer(BaseOptimizer["LBFGSBLogData", LBFGSBConfig]):
         )
 
         self._gradient_fn = gradient_fn
-        self._finite_diff_epsilon = config._fd_eps_actual
         self._gradient_strategy = gradient_strategy or CentralFD()
         self._line_search = line_search or MoreThuenteLineSearch()
         self._memory_size = config.m
         self._machine_epsilon = np.finfo(float).eps
 
-        # A supplied InitialGeometry (e.g. a CMA-ES-derived B_0 from a handoff)
-        # is used directly and overrides ``config.initial_hessian``; otherwise
-        # build one from the config's raw curvature as before.
+        # Resolve the finite-difference step: explicit config values pass
+        # through untouched; the 0 = auto sentinel picks the step that
+        # balances truncation against rounding error for the strategy in
+        # use — eps**(1/3) for central differences, sqrt(eps) for forward.
+        if config.fd_eps > 0:
+            self._finite_diff_epsilon = config.fd_eps
+        elif isinstance(self._gradient_strategy, ForwardFD):
+            self._finite_diff_epsilon = float(self._machine_epsilon**0.5)
+        else:
+            self._finite_diff_epsilon = float(self._machine_epsilon ** (1.0 / 3.0))
+
+        # A supplied InitialGeometry (e.g. a CMA-ES-derived B_0 from a
+        # handoff) and ``config.initial_hessian`` are mutually exclusive
+        # seams; otherwise build one from the config's raw curvature as
+        # before.
         if initial_geometry is not None:
+            if config.initial_hessian is not None:
+                raise ValueError(
+                    "Pass either config.initial_hessian or initial_geometry, "
+                    "not both."
+                )
             self._initial_hessian = initial_geometry
         else:
             self._initial_hessian = InitialHessian(
@@ -131,6 +147,8 @@ class LBFGSBOptimizer(BaseOptimizer["LBFGSBLogData", LBFGSBConfig]):
             x=x,
             eps=self._finite_diff_epsilon,
             f_at_x=function_value_at_x,
+            lower_bounds=self.lower_bounds,
+            upper_bounds=self.upper_bounds,
         )
 
     def _compute_directional_derivative(
@@ -150,9 +168,30 @@ class LBFGSBOptimizer(BaseOptimizer["LBFGSBLogData", LBFGSBConfig]):
             return f_trial, float(np.dot(self._cached_gradient, direction))
         else:
             epsilon = self._finite_diff_epsilon
-            f_forward = self.evaluate(x_trial + epsilon * direction)
-            f_backward = self.evaluate(x_trial - epsilon * direction)
-            return f_trial, (f_forward - f_backward) / (2.0 * epsilon)
+            forward_point = x_trial + epsilon * direction
+            backward_point = x_trial - epsilon * direction
+            forward_feasible = bool(
+                np.all(forward_point >= self.lower_bounds)
+                and np.all(forward_point <= self.upper_bounds)
+            )
+            backward_feasible = bool(
+                np.all(backward_point >= self.lower_bounds)
+                and np.all(backward_point <= self.upper_bounds)
+            )
+            if forward_feasible == backward_feasible:
+                # Both probes feasible: central difference.  (Also the
+                # degenerate fallback when neither probe fits the box.)
+                f_forward = self.evaluate(forward_point)
+                f_backward = self.evaluate(backward_point)
+                return f_trial, (f_forward - f_backward) / (2.0 * epsilon)
+            if forward_feasible:
+                # Backward probe would exit the box (x_trial sits on a
+                # bound): one-sided difference toward the feasible side,
+                # anchored on the already-evaluated f_trial.
+                f_forward = self.evaluate(forward_point)
+                return f_trial, (f_forward - f_trial) / epsilon
+            f_backward = self.evaluate(backward_point)
+            return f_trial, (f_trial - f_backward) / epsilon
 
     # Projected gradient
 
@@ -597,16 +636,6 @@ class LBFGSBOptimizer(BaseOptimizer["LBFGSBLogData", LBFGSBConfig]):
         # B_0^{-1} restricted to free variables, applied to the reduced gradient
         # For diagonal B_0: element-wise division
         # For dense B_0: extract the free-variable subblock and solve
-        reduced_gradient_free = reduced_gradient
-        B0_inv_reduced_gradient = np.zeros(num_free)
-        for j in range(num_free):
-            idx = free_variable_indices[j]
-            B0_inv_reduced_gradient[j] = B0.solve(
-                np.eye(1, self.dimensions, idx).flatten()
-            )[idx] * reduced_gradient[j]
-
-        # For dense B_0, the per-element solve above is wrong — we need the
-        # full subblock inverse. Recompute properly.
         if B0.mode == InitialHessianMode.DENSE:
             # Extract the free-variable subblock of B_0
             assert B0._matrix is not None
@@ -729,21 +758,23 @@ class LBFGSBOptimizer(BaseOptimizer["LBFGSBLogData", LBFGSBConfig]):
         if is_first_iteration:
             return 1.0
 
-        max_step = 1e10
-        for i in range(self.dimensions):
-            if direction[i] < -self._machine_epsilon:
-                distance_to_lower = self.lower_bounds[i] - x[i]
-                if distance_to_lower >= 0:
-                    max_step = 0.0
-                    break
-                max_step = min(max_step, distance_to_lower / direction[i])
-            elif direction[i] > self._machine_epsilon:
-                distance_to_upper = self.upper_bounds[i] - x[i]
-                if distance_to_upper <= 0:
-                    max_step = 0.0
-                    break
-                max_step = min(max_step, distance_to_upper / direction[i])
+        # Exact per-component step to the bound faced by each direction
+        # component; zero components never limit the step (-> inf).  Taking
+        # the exact minimum guarantees x + alpha*d stays inside the box, so
+        # the belt-and-braces clip after the line search is a no-op and the
+        # cached f/gradient always describe the accepted point.
+        with np.errstate(divide="ignore", invalid="ignore"):
+            steps_to_bound = np.where(
+                direction > 0,
+                (self.upper_bounds - x) / direction,
+                np.where(
+                    direction < 0,
+                    (self.lower_bounds - x) / direction,
+                    np.inf,
+                ),
+            )
 
+        max_step = float(min(np.min(steps_to_bound), 1e10))
         return max(max_step, 0.0)
 
     # Main loop
@@ -866,6 +897,9 @@ class LBFGSBOptimizer(BaseOptimizer["LBFGSBLogData", LBFGSBConfig]):
             ) -> tuple[float, float]:
                 return self._compute_directional_derivative(_x, _d, alpha)
 
+            def phi_only(alpha: float, _x=x, _d=direction) -> float:
+                return self.evaluate(_x + alpha * _d)
+
             line_search_result = self._line_search.search(
                 phi_dphi=phi_and_dphi,
                 stp0=initial_step,
@@ -876,9 +910,21 @@ class LBFGSBOptimizer(BaseOptimizer["LBFGSBLogData", LBFGSBConfig]):
                 gtol=config.gtol_ls,
                 xtol=config.xtol_ls,
                 maxiter=config.max_ls_iter,
+                phi=phi_only,
             )
 
             accepted_step = line_search_result.step
+
+            if (
+                not line_search_result.converged
+                and line_search_result.step > 0
+                and line_search_result.f_new < best_fitness
+            ):
+                # Even a failed search evaluated real trial points; keep a
+                # strictly better feasible one for reporting without
+                # accepting the step into the algorithm state.
+                best_fitness = line_search_result.f_new
+                best_solution = (x + line_search_result.step * direction).copy()
 
             if accepted_step <= 0 or (
                 not line_search_result.converged and self._num_corrections == 0
@@ -896,18 +942,25 @@ class LBFGSBOptimizer(BaseOptimizer["LBFGSBLogData", LBFGSBConfig]):
 
             consecutive_resets = 0
             step_vector = accepted_step * direction
+            x_line_search = x + step_vector
             x_new = np.clip(
-                x + step_vector, self.lower_bounds, self.upper_bounds
+                x_line_search, self.lower_bounds, self.upper_bounds
             )
+            clip_moved_x = not np.array_equal(x_new, x_line_search)
             step_vector = x_new - x
 
             if self._cached_gradient is not None:
                 gradient_new = self._cached_gradient
                 function_value_new = line_search_result.f_new
-            else:
+            elif clip_moved_x:
                 function_value_new, gradient_new = (
                     self._evaluate_function_and_gradient(x_new)
                 )
+            else:
+                # The line search already evaluated f at exactly x_new; only
+                # the gradient is missing.
+                function_value_new = line_search_result.f_new
+                gradient_new = self._compute_gradient(x_new, function_value_new)
 
             gradient_difference = gradient_new - gradient
 

--- a/declivity/algorithms/mfcmaes/mfcmaes_config.py
+++ b/declivity/algorithms/mfcmaes/mfcmaes_config.py
@@ -70,12 +70,6 @@ class MFCMAESConfig(PopulationBaseConfig):
     tolfun: float = 1e-12
     """Tolerance for function value differences"""
 
-    tolx: float = field(init=False)
-    """Tolerance for changes in x"""
-
-    tolxup: float = 1e4
-    """Upper tolerance for step size"""
-
     # Computed/derived parameters
     mu: int = field(init=False)
     """Number of parents"""
@@ -120,8 +114,6 @@ class MFCMAESConfig(PopulationBaseConfig):
     def _recalculate_derived_params(self) -> None:
         """Recalculate derived parameters using the R reference formulas
         (``nm-cma-es-vectorized.R`` lines 54–68)."""
-        self.tolx = 1e-12 * self.sigma
-
         self.mu = default_mu(self.population_size)
 
         # Compute weights and mu_eff (uniform weights, mu_eff == mu).

--- a/declivity/algorithms/mfcmaes/mfcmaes_optimizer.py
+++ b/declivity/algorithms/mfcmaes/mfcmaes_optimizer.py
@@ -79,8 +79,8 @@ class MFCMAESOptimizer(PopulationOptimizer["MFCMAESLogData", MFCMAESConfig]):
 
         Sized by the archive ``window`` (not the total budget): the table is
         only ever read through its first ``window`` entries — see
-        :meth:`_generate_population`, which slices
-        ``decay_table[window - 1 :: -1]`` — so ``window`` factors suffice
+        :meth:`_generate_population`, which reverses the full table
+        (``decay_table[::-1]``) — so ``window`` factors suffice
         regardless of how many generations the run lasts."""
         t = np.arange(1, self.config.window + 1)
         self.decay_table = (1 - self.config.c_cov) ** ((t - 1) / 2)
@@ -101,33 +101,38 @@ class MFCMAESOptimizer(PopulationOptimizer["MFCMAESLogData", MFCMAESConfig]):
         return np.concatenate([arr[-n:], arr[:-n]])
 
     def _generate_population(self, generation: int) -> NDArray[np.float64]:
-        # Get decay factors for current generation
-        window_size = min(generation, self.config.window)
-        decay = self.decay_table[self.config.window - 1 :: -1][:window_size]
+        # Get decay factors for current generation.  Match the reference
+        # (R lines 136–138): always reverse the FULL window-length table
+        # and cyclically shift by ``generation - 1``; before the archive
+        # fills, its zero columns absorb the meaningless decay entries.
+        decay = self.decay_table[::-1].copy()  # length = window
         decay = self._shift_array(decay, generation - 1)
 
-        decay_rep = np.repeat(decay, self.config.mu)[: generation * self.config.mu]
-
-        w = np.tile(np.sqrt(self.config.weights), window_size)[: len(decay_rep)]
-
-        r_mu = self.rng.standard_normal((len(decay_rep), self.config.population_size))
-
-        relevant_d_size = min(generation * self.config.mu, self.d_history.shape[1])
-        d_relevant = self.d_history[:, :relevant_d_size]
-
-        weighted_d = d_relevant * (decay_rep[:relevant_d_size] * w[:relevant_d_size])
+        # decay index of archive column c is ``c // mu`` (its generation
+        # slot); weight index is ``c % mu`` (its selection rank) — the
+        # d_history layout is slot-major (see :meth:`_d_range`), so
+        # ``np.tile`` (not the reference's ``np.repeat``, which pairs the
+        # weight by ``c // window``) gives each column sqrt(weight of its
+        # rank).  Identical numerically under the uniform weights both
+        # implementations use.
+        decay_rep = np.repeat(decay, self.config.mu)  # length = window * mu
+        w = np.tile(np.sqrt(self.config.weights), self.config.window)
 
         # Late-iter decay-table underflow makes the matmul multiply
         # denormalised numbers — numpy reports spurious "divide by
         # zero" / "invalid" / "overflow" warnings even though the
         # accumulated result is mathematically well-defined.
         with np.errstate(divide="ignore", invalid="ignore", over="ignore", under="ignore"):
-            rank_mu = np.sqrt(self.config.c_mu) * (weighted_d @ r_mu[:relevant_d_size, :])
+            r_mu = self.rng.standard_normal(
+                (self.config.window * self.config.mu, self.config.population_size)
+            )
+            rank_mu = np.sqrt(self.config.c_mu) * (
+                self.d_history @ (r_mu * decay_rep[:, np.newaxis] * w[:, np.newaxis])
+            )
 
-            r_1 = self.rng.standard_normal((window_size, self.config.population_size))
-            p_relevant = self.p_history[:, :window_size]
+            r_1 = self.rng.standard_normal((self.config.window, self.config.population_size))
             rank_1 = np.sqrt(self.config.c_1) * (
-                p_relevant @ (r_1 * decay[:window_size, np.newaxis])
+                self.p_history @ (r_1 * decay[:, np.newaxis])
             )
 
         if generation <= self.config.window:
@@ -154,7 +159,6 @@ class MFCMAESOptimizer(PopulationOptimizer["MFCMAESLogData", MFCMAESConfig]):
         self._begin_run()
         best_fitness = float("inf")
         best_solution = self.initial_point.copy()
-        worst_fitness = float("inf")
         message = None
         generation = 0
 
@@ -176,6 +180,7 @@ class MFCMAESOptimizer(PopulationOptimizer["MFCMAESLogData", MFCMAESConfig]):
         initial_pen = np.where(
             np.isfinite(initial_pen), initial_pen, np.finfo(np.float64).max / 2.0
         )
+        self.constraint_violations = int(np.sum(initial_pen > 1.0))
         initial_raw = np.array(
             [self.evaluate(initial_vx[:, i]) for i in range(initial_vx.shape[1])]
         )
@@ -219,8 +224,30 @@ class MFCMAESOptimizer(PopulationOptimizer["MFCMAESLogData", MFCMAESConfig]):
 
         self._update_sigma_ppmf_first(initial_vx, initial_fitness)
 
+        self.logger.log_iteration(
+            iteration=1,
+            evaluations=self.evaluations,
+            best_fitness=best_fitness,
+            worst_fitness=float(np.max(initial_fitness)),
+            mean_fitness=float(np.mean(initial_fitness)),
+            sigma=self.sigma,
+            p_succ=self.p_succ,
+            midpoint_fitness=self.midpoint_fitness,
+            constraint_violations=self.constraint_violations,
+            fitness=initial_fitness,
+            population=initial_vx.T if self.config.diag_pop else None,
+            best_solution=best_solution,
+            pc=self.pc,
+            mean_vector=self.mean,
+        )
+
+        # Same algorithm-internal ``tolfun`` convergence test as the main
+        # loop (see below) — the reference applies it on iteration 1 too.
+        if float(initial_fitness[arindex[0]]) <= self.config.tolfun:
+            message = "Target fitness reached."
+
         generation = 1
-        while not self.should_stop(generation, best_fitness):
+        while message is None and not self.should_stop(generation, best_fitness):
             generation += 1
 
             d = self._generate_population(generation)
@@ -243,8 +270,6 @@ class MFCMAESOptimizer(PopulationOptimizer["MFCMAESLogData", MFCMAESConfig]):
                 if valid_raw[wb] < best_fitness:
                     best_fitness = float(valid_raw[wb])
                     best_solution = valid_vx[:, wb].copy()
-
-            worst_fitness = max(worst_fitness, float(np.max(fitness_values)))
 
             arindex = np.argsort(fitness_values)
             aripop = arindex[: self.config.mu]
@@ -271,7 +296,7 @@ class MFCMAESOptimizer(PopulationOptimizer["MFCMAESLogData", MFCMAESConfig]):
                 iteration=generation,
                 evaluations=self.evaluations,
                 best_fitness=best_fitness,
-                worst_fitness=worst_fitness,
+                worst_fitness=float(np.max(fitness_values)),
                 mean_fitness=float(np.mean(fitness_values)),
                 sigma=self.sigma,
                 p_succ=self.p_succ,
@@ -284,12 +309,12 @@ class MFCMAESOptimizer(PopulationOptimizer["MFCMAESLogData", MFCMAESConfig]):
                 mean_vector=self.mean,
             )
 
-            # Match R: ``terminate.stopfitness`` checks the best raw
+            # Match R: ``terminate.stopfitness`` checks the best penalised
             # fitness from this generation against ``stopfitness``.  The
             # shared evaluation / time / target budget is owned by the
             # injected stopping condition (the main-loop guard above); this
             # is the algorithm-internal ``tolfun`` convergence test only.
-            if float(fitness_values[0]) <= self.config.tolfun:
+            if float(fitness_values[arindex[0]]) <= self.config.tolfun:
                 message = "Target fitness reached."
                 break
 
@@ -333,9 +358,9 @@ class MFCMAESOptimizer(PopulationOptimizer["MFCMAESLogData", MFCMAESConfig]):
         R for the rest of the run.
         """
         if not self.config.use_ppmf:
-            self.midpoint_fitness = np.inf
+            self.midpoint_fitness = float("nan")
             self.prev_midpoint_fitness = np.inf
-            self.p_succ = 0.0
+            self.p_succ = float("nan")
             return
 
         self._update_sigma_ppmf(vx, fitness_values)
@@ -349,14 +374,12 @@ class MFCMAESOptimizer(PopulationOptimizer["MFCMAESLogData", MFCMAESConfig]):
         If use_ppmf is False, sigma remains constant.
         """
         if not self.config.use_ppmf:
-            # Keep sigma constant, just calculate p_succ for logging
-            population_midpoint = np.mean(vx, axis=1)
-            self.midpoint_fitness = self.evaluate(population_midpoint)
-
-            num_successes = np.sum(fitness_values < self.prev_midpoint_fitness)
-            self.p_succ = num_successes / self.config.population_size
-
-            self.prev_midpoint_fitness = self.midpoint_fitness
+            # Keep sigma constant.  The reference's ``sigma_updater =
+            # "identity"`` makes no midpoint call, so spend no evaluation
+            # here either — log NaN for the midpoint-derived fields to
+            # keep the diagnostic series aligned.
+            self.midpoint_fitness = float("nan")
+            self.p_succ = float("nan")
             return
 
         self.prev_midpoint_fitness = self.midpoint_fitness

--- a/declivity/algorithms/powell/powell_optimizer.py
+++ b/declivity/algorithms/powell/powell_optimizer.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Callable, Union, final, TYPE_CHECKING
 
 import numpy as np
@@ -146,6 +147,15 @@ class PowellOptimizer(BaseOptimizer["PowellLogData", PowellConfig]):
         n = self.dimensions
 
         x = self.initial_point.copy()
+        # SciPy clips an out-of-bounds initial guess into the box (with a
+        # warning) before the first evaluation; feasible starts are
+        # untouched, keeping trajectories byte-identical.
+        if np.any(x < self.lower_bounds) or np.any(x > self.upper_bounds):
+            warnings.warn(
+                "Initial guess is not within the specified bounds",
+                stacklevel=2,
+            )
+            x = np.clip(x, self.lower_bounds, self.upper_bounds)
         direc = self._initial_directions.copy()
 
         fval = self.evaluate(x)
@@ -212,6 +222,13 @@ class PowellOptimizer(BaseOptimizer["PowellLogData", PowellConfig]):
                     f"Converged: sweep decrease {relative_decrease:.2e} within "
                     f"ftol bound {decrease_bound:.2e}"
                 )
+                break
+            # Budget check placed exactly where SciPy tests maxfun/maxiter:
+            # after the ftol test, before the extrapolated point spends
+            # another evaluation.  ``termination_message`` stays None so the
+            # final-message logic falls through to ``self.stop_message``,
+            # identical to the top-of-loop exit.
+            if self.should_stop(iteration, best_fitness):
                 break
             if np.isnan(fx) and np.isnan(fval):
                 termination_message = "NaN region encountered"

--- a/declivity/logging/cmaes_logger.py
+++ b/declivity/logging/cmaes_logger.py
@@ -157,9 +157,9 @@ class CMAESLogger(BaseLogger[CMAESLogData]):
                 self.logs.max_eigenvalue.append(float(eigenvalues[-1]))
                 self.logs.min_eigenvalue.append(float(eigenvalues[0]))
 
-        # Step-size
-        if self.config.diag_sigma:
-            self.logs.sigma.append(sigma)
+        # Step-size (cheap scalar — always logged so the default Step Size
+        # panel is never blank)
+        self.logs.sigma.append(sigma)
 
         # Evolution paths
         if pc is not None:

--- a/declivity/logging/des_logger.py
+++ b/declivity/logging/des_logger.py
@@ -15,19 +15,16 @@ class DESLogData(PopulationLogData):
 
     ft: list[float] = field(default_factory=list)
     evolution_path: list[NDArray[np.float64]] = field(default_factory=list)
-    step_size: list[float] = field(default_factory=list)
 
     def clear(self) -> None:
         super().clear()
         self.ft.clear()
         self.evolution_path.clear()
-        self.step_size.clear()
 
     def to_dict(self) -> dict[str, list[Any]]:
         return super().to_dict() | {
             "ft": self.ft,
             "evolution_path": self.evolution_path,
-            "step_size": self.step_size,
         }
 
 
@@ -81,10 +78,7 @@ class DESLogger(BaseLogger[DESLogData]):
             if len(eigenvalues) > 0:
                 self.logs.condition_number.append(eigenvalues[0] / eigenvalues[-1])
 
-        if self.config.diag_ft:
-            self.logs.ft.append(ft)
-
         if evolution_path is not None:
             self.logs.evolution_path.append(evolution_path.copy())
 
-        self.logs.step_size.append(ft)
+        self.logs.ft.append(ft)

--- a/declivity/utils/__init__.py
+++ b/declivity/utils/__init__.py
@@ -46,6 +46,7 @@ from declivity.utils.line_search import (
     ScalarSearchResult,
     BrentLineSearch,
     GoldenSectionLineSearch,
+    DerivativeFreeLineSearchType,
 )
 from declivity.utils.initial_geometry import (
     InitialGeometry,
@@ -109,6 +110,7 @@ __all__ = [
     "ScalarSearchResult",
     "BrentLineSearch",
     "GoldenSectionLineSearch",
+    "DerivativeFreeLineSearchType",
     # Initial geometry surface (shared learned-curvature object)
     "InitialGeometry",
     "InitialHessian",

--- a/declivity/utils/constraint_handlers.py
+++ b/declivity/utils/constraint_handlers.py
@@ -149,8 +149,8 @@ class BoxConstraintHandler(ConstraintHandler):
         keeps the per-row fallback.
         """
         if self.strategy is BoxStrategy.CLAMP:
-            clipped = np.clip(population, self.lower_bounds, self.upper_bounds)
-            return self._remove_inf_nan(clipped)
+            sanitized = self._remove_inf_nan(population)
+            return np.clip(sanitized, self.lower_bounds, self.upper_bounds)
         return super().repair_batch(population)
 
     @override
@@ -164,9 +164,13 @@ class BoxConstraintHandler(ConstraintHandler):
     # ------------------------------------------------------------------
 
     def _repair_clamp(self, x: NDArray[np.float64]) -> NDArray[np.float64]:
-        """Clamp repair — mirrors ClampBoundaryHandler.repair (lines 132–143)."""
-        x_repaired = np.clip(x, self.lower_bounds, self.upper_bounds)
-        return self._remove_inf_nan(x_repaired)
+        """Clamp repair — sanitize non-finite values, then clip into the box.
+
+        Sanitizing must come first: ``np.clip`` propagates NaN, and a
+        post-clip replacement would land far outside the bounds.
+        """
+        x_repaired = self._remove_inf_nan(x)
+        return np.clip(x_repaired, self.lower_bounds, self.upper_bounds)
 
     def _repair_bounce_back(self, x: NDArray[np.float64]) -> NDArray[np.float64]:
         """Bounce-back repair — mirrors BounceBackBoundaryHandler.repair (lines 66–106)."""
@@ -175,8 +179,15 @@ class BoxConstraintHandler(ConstraintHandler):
 
         x_repaired = x.copy()
 
+        # Zero-width dimensions have no interior to bounce within — the
+        # modulo below would divide by zero (NaN).  Pin them to the unique
+        # feasible value and exclude them from the bounce loops.
+        degenerate = self.upper_bounds == self.lower_bounds
+        if np.any(degenerate):
+            x_repaired[degenerate] = self.lower_bounds[degenerate]
+
         # Fix lower bound violations
-        lower_violations = x < self.lower_bounds
+        lower_violations = (x < self.lower_bounds) & ~degenerate
         if np.any(lower_violations):
             indices = np.where(lower_violations)[0]
             for i in indices:
@@ -185,7 +196,7 @@ class BoxConstraintHandler(ConstraintHandler):
                 ) % (self.upper_bounds[i] - self.lower_bounds[i])
 
         # Fix upper bound violations
-        upper_violations = x > self.upper_bounds
+        upper_violations = (x > self.upper_bounds) & ~degenerate
         if np.any(upper_violations):
             indices = np.where(upper_violations)[0]
             for i in indices:
@@ -203,10 +214,16 @@ class BoxConstraintHandler(ConstraintHandler):
         return x_repaired
 
     def _remove_inf_nan(self, x: NDArray[np.float64]) -> NDArray[np.float64]:
-        """Replace NaN / Inf with np.finfo(float).max — mirrors both handler classes."""
+        """Replace non-finite values with the extreme finite floats.
+
+        NaN and ``+inf`` map to ``np.finfo(float).max``; ``-inf`` maps to
+        ``np.finfo(float).min`` — direction-preserving, so a subsequent
+        clip lands each value on the correct bound.
+        """
         result = x.copy()
         result[np.isnan(result)] = np.finfo(float).max
-        result[np.isinf(result)] = np.finfo(float).max
+        result[np.isposinf(result)] = np.finfo(float).max
+        result[np.isneginf(result)] = np.finfo(float).min
         return result
 
 

--- a/declivity/utils/covariance.py
+++ b/declivity/utils/covariance.py
@@ -127,15 +127,18 @@ def weighted_covariance(
             f"population rows ({population.shape[0]})"
         )
 
+    internal_mean = mean is None
     if mean is None:
         mean = population.T @ weights
 
     centered = population - mean
     cov = (centered.T * weights) @ centered
 
-    # Weighted case: rank is at most min(n, d) since mean may be external
+    # Weighted case: an external mean keeps rank at most min(n, d), but
+    # centering on the internally computed weighted mean costs one degree
+    # of freedom (mirrors empirical_covariance) — rank at most n - 1.
     n = population.shape[0]
-    rank = min(n, population.shape[1])
+    rank = min(n - 1 if internal_mean else n, population.shape[1])
 
     return _decompose(cov, mean, rank)
 

--- a/declivity/utils/gradient_strategies.py
+++ b/declivity/utils/gradient_strategies.py
@@ -25,6 +25,7 @@ counter naturally.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from enum import Enum
 from typing import Callable
 
 import numpy as np
@@ -47,6 +48,8 @@ class GradientStrategy(ABC):
         x: NDArray[np.float64],
         eps: float,
         f_at_x: float | None = None,
+        lower_bounds: NDArray[np.float64] | None = None,
+        upper_bounds: NDArray[np.float64] | None = None,
     ) -> NDArray[np.float64]:
         """Approximate ``∇f(x)``.
 
@@ -65,8 +68,17 @@ class GradientStrategy(ABC):
             forward FD uses ``eps`` one-sided).
         f_at_x:
             Optional cached value of ``f(x)``.  Forward FD can reuse it
-            and save one evaluation per gradient; symmetric schemes
-            ignore it.
+            and save one evaluation per gradient; central FD needs it
+            only for coordinates that fall back to a one-sided
+            difference at a bound.
+        lower_bounds, upper_bounds:
+            Optional box bounds, shape ``(dim,)``.  When supplied, a
+            perturbed point that would leave the box switches that
+            coordinate to a one-sided difference on the feasible side
+            (standard practice for bound-constrained solvers whose
+            iterates sit exactly on bounds).  ``None`` (or probes
+            strictly inside the box) reproduces the unconstrained
+            scheme exactly.
 
         Returns
         -------
@@ -96,15 +108,26 @@ class ForwardFD(GradientStrategy):
         x: NDArray[np.float64],
         eps: float,
         f_at_x: float | None = None,
+        lower_bounds: NDArray[np.float64] | None = None,
+        upper_bounds: NDArray[np.float64] | None = None,
     ) -> NDArray[np.float64]:
         if f_at_x is None:
             f_at_x = f(x)
         num_vars = len(x)
         gradient = np.zeros(num_vars)
         for i in range(num_vars):
-            x_forward = x.copy()
-            x_forward[i] += eps
-            gradient[i] = (f(x_forward) - f_at_x) / eps
+            step = eps
+            if (
+                upper_bounds is not None
+                and x[i] + eps > upper_bounds[i]
+                and (lower_bounds is None or x[i] - eps >= lower_bounds[i])
+            ):
+                # Forward probe would exit the box: difference backward
+                # instead (one-sided on the feasible side).
+                step = -eps
+            x_probe = x.copy()
+            x_probe[i] += step
+            gradient[i] = (f(x_probe) - f_at_x) / step
         return gradient
 
 
@@ -128,16 +151,64 @@ class CentralFD(GradientStrategy):
         x: NDArray[np.float64],
         eps: float,
         f_at_x: float | None = None,
+        lower_bounds: NDArray[np.float64] | None = None,
+        upper_bounds: NDArray[np.float64] | None = None,
     ) -> NDArray[np.float64]:
-        del f_at_x  # symmetric scheme does not reuse the centre value
         num_vars = len(x)
         gradient = np.zeros(num_vars)
         for i in range(num_vars):
-            x_forward = x.copy()
-            x_backward = x.copy()
-            x_forward[i] += eps
-            x_backward[i] -= eps
-            gradient[i] = (f(x_forward) - f(x_backward)) / (2.0 * eps)
+            forward_ok = upper_bounds is None or x[i] + eps <= upper_bounds[i]
+            backward_ok = lower_bounds is None or x[i] - eps >= lower_bounds[i]
+            if forward_ok == backward_ok:
+                # Both probes feasible: symmetric difference.  (Also the
+                # degenerate fallback when the box is narrower than 2*eps.)
+                x_forward = x.copy()
+                x_backward = x.copy()
+                x_forward[i] += eps
+                x_backward[i] -= eps
+                gradient[i] = (f(x_forward) - f(x_backward)) / (2.0 * eps)
+            elif forward_ok:
+                # Backward probe would exit the box: one-sided forward,
+                # anchored on the (lazily evaluated) centre value.
+                if f_at_x is None:
+                    f_at_x = f(x)
+                x_forward = x.copy()
+                x_forward[i] += eps
+                gradient[i] = (f(x_forward) - f_at_x) / eps
+            else:
+                if f_at_x is None:
+                    f_at_x = f(x)
+                x_backward = x.copy()
+                x_backward[i] -= eps
+                gradient[i] = (f_at_x - f(x_backward)) / eps
         return gradient
+
+
+class GradientStrategyType(Enum):
+    """
+    Discoverability enum listing all built-in gradient strategies.
+
+    Call ``.build()`` to obtain a ready-to-use :class:`GradientStrategy`
+    instance without importing concrete classes.
+    """
+
+    FORWARD_FD = "forward_fd"
+    CENTRAL_FD = "central_fd"
+
+    def build(self) -> GradientStrategy:
+        """
+        Construct the matching :class:`GradientStrategy`.
+
+        Returns
+        -------
+        GradientStrategy
+            Concrete strategy for this enum member.
+        """
+        if self is GradientStrategyType.FORWARD_FD:
+            return ForwardFD()
+        elif self is GradientStrategyType.CENTRAL_FD:
+            return CentralFD()
+        # Exhaustive match — new members must extend this method.
+        raise NotImplementedError(f"No build() implementation for {self!r}")
 
 

--- a/declivity/utils/helpers.py
+++ b/declivity/utils/helpers.py
@@ -94,26 +94,3 @@ def delete_inf_nan(x: NDArray[np.float64]) -> NDArray[np.float64]:
     result[np.isnan(result)] = np.finfo(float).max
     result[np.isinf(result)] = np.finfo(float).max
     return result
-
-
-def sample_from_history(
-    history: list[NDArray[np.float64]],
-    history_sample: NDArray[np.float64],
-    lambda_: int,
-) -> NDArray[np.float64]:
-    """
-    Sample indices from history entries.
-
-    Args:
-        history: list of history entries
-        history_sample: Indices of history entries to sample from
-        lambda_: Number of samples to generate
-
-    Returns:
-        Array of sampled indices
-    """
-    result = np.zeros(lambda_, dtype=int)
-    for i in range(lambda_):
-        history_idx = history_sample[i]
-        result[i] = np.random.randint(0, history[history_idx].shape[1])
-    return result

--- a/declivity/utils/line_search/__init__.py
+++ b/declivity/utils/line_search/__init__.py
@@ -20,6 +20,7 @@ L-BFGS-B, Brent for Powell).
 from declivity.utils.line_search.gradient import (
     ArmijoBacktracking,
     GradientLineSearch,
+    GradientLineSearchType,
     LineSearchResult,
     LineSearchStrategy,
     MoreThuenteLineSearch,
@@ -30,6 +31,7 @@ from declivity.utils.line_search.derivative_free import (
     BracketError,
     BrentLineSearch,
     DerivativeFreeLineSearch,
+    DerivativeFreeLineSearchType,
     GoldenSectionLineSearch,
     ScalarSearchResult,
     bounded_minimize,
@@ -40,6 +42,7 @@ from declivity.utils.line_search.derivative_free import (
 __all__ = [
     # Gradient-based branch
     "GradientLineSearch",
+    "GradientLineSearchType",
     "LineSearchStrategy",
     "LineSearchResult",
     "MoreThuenteLineSearch",
@@ -51,6 +54,7 @@ __all__ = [
     "ScalarSearchResult",
     "BrentLineSearch",
     "GoldenSectionLineSearch",
+    "DerivativeFreeLineSearchType",
     "BracketError",
     "bracket_minimum",
     "brent_minimize",

--- a/declivity/utils/line_search/derivative_free.py
+++ b/declivity/utils/line_search/derivative_free.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from enum import Enum
 from typing import Callable, final, override
 
 import numpy as np
@@ -9,6 +10,7 @@ __all__ = [
     "DerivativeFreeLineSearch",
     "BrentLineSearch",
     "GoldenSectionLineSearch",
+    "DerivativeFreeLineSearchType",
 ]
 
 
@@ -191,6 +193,46 @@ class GoldenSectionLineSearch(DerivativeFreeLineSearch):
             )
 
         return _golden_section(phi, lower, upper, xatol=tol / 100.0, maxiter=maxiter)
+
+
+class DerivativeFreeLineSearchType(Enum):
+    """
+    Discoverability enum listing all built-in derivative-free line searches.
+
+    Call ``.build()`` to obtain a ready-to-use
+    ``DerivativeFreeLineSearch`` instance without importing concrete
+    classes directly.
+
+    Members
+    -------
+    BRENT
+        SciPy-faithful Brent search: automatic downhill bracketing on
+        unbounded intervals, golden section + parabolic interpolation on
+        bounded ones.  Powell's default.
+    GOLDEN_SECTION
+        Pure golden-section shrinking — no parabolic acceleration.
+        Linear convergence, but unconditionally safe on noisy or kinked
+        objectives.
+    """
+
+    BRENT = "brent"
+    GOLDEN_SECTION = "golden_section"
+
+    def build(self) -> DerivativeFreeLineSearch:
+        """
+        Construct and return a fresh ``DerivativeFreeLineSearch`` instance.
+
+        Returns
+        -------
+        DerivativeFreeLineSearch
+            A concrete line search for this enum member.
+        """
+        if self is DerivativeFreeLineSearchType.BRENT:
+            return BrentLineSearch()
+        elif self is DerivativeFreeLineSearchType.GOLDEN_SECTION:
+            return GoldenSectionLineSearch()
+        # Exhaustive match — new members must extend this method.
+        raise NotImplementedError(f"No build() implementation for {self!r}")
 
 
 # ---------------------------------------------------------------------------

--- a/declivity/utils/line_search/gradient.py
+++ b/declivity/utils/line_search/gradient.py
@@ -20,6 +20,7 @@ References:
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from enum import Enum
 from typing import Callable, final, override
 
 import numpy as np
@@ -66,6 +67,7 @@ class GradientLineSearch(ABC):
         gtol: float,
         xtol: float,
         maxiter: int,
+        phi: Callable[[float], float] | None = None,
     ) -> LineSearchResult:
         """Find a step ``alpha`` satisfying the strategy's acceptance test.
 
@@ -90,7 +92,13 @@ class GradientLineSearch(ABC):
             Interval-width tolerance (used by bracketing searches;
             ignored by pure Armijo backtracking).
         maxiter:
-            Maximum trial evaluations.
+            Maximum number of trial steps.
+        phi:
+            Optional value-only evaluator ``phi(alpha)``.  Searches that
+            never use ``phi'(alpha)`` at trial points (Armijo) call this
+            instead of ``phi_dphi`` — in finite-difference mode that cuts
+            the per-trial cost from three evaluations to one.  Searches
+            that need the derivative (More-Thuente) ignore it.
         """
         ...
 
@@ -123,7 +131,9 @@ class MoreThuenteLineSearch(GradientLineSearch):
         gtol: float,
         xtol: float,
         maxiter: int,
+        phi: Callable[[float], float] | None = None,
     ) -> LineSearchResult:
+        del phi  # More-Thuente needs phi'(alpha) at every trial point.
         return more_thuente_search(
             phi_dphi, stp0, phi0, dphi0, stpmax, ftol, gtol, xtol, maxiter
         )
@@ -137,7 +147,9 @@ class ArmijoBacktracking(GradientLineSearch):
     only the sufficient-decrease condition, contracting the trial step
     on each rejected trial.  ``gtol`` and ``xtol`` are accepted to
     keep the interface uniform with :class:`MoreThuenteLineSearch` but
-    are unused.
+    are unused.  When the caller supplies the value-only ``phi``
+    evaluator, each trial costs a single function evaluation (Armijo
+    never needs ``phi'(alpha)`` at trial points).
     """
 
     @override
@@ -152,9 +164,12 @@ class ArmijoBacktracking(GradientLineSearch):
         gtol: float,
         xtol: float,
         maxiter: int,
+        phi: Callable[[float], float] | None = None,
     ) -> LineSearchResult:
         del gtol, xtol  # Armijo ignores Wolfe-style curvature / bracket bounds.
-        return armijo_search(phi_dphi, stp0, phi0, dphi0, stpmax, ftol, maxiter)
+        return armijo_search(
+            phi_dphi, stp0, phi0, dphi0, stpmax, ftol, maxiter, phi=phi
+        )
 
 
 
@@ -181,6 +196,9 @@ def more_thuente_search(
     the sufficient decrease condition holds with a non-negative derivative.
     Stage 2 directly minimizes f within the bracket.
     """
+    if maxiter < 1:
+        raise ValueError("maxiter must be at least 1.")
+
     step_min = 0.0
     extrapolation_lower = 1.1
     extrapolation_upper = 4.0
@@ -190,6 +208,10 @@ def more_thuente_search(
         return LineSearchResult(
             step=0.0, f_new=phi0, dphi_new=dphi0, num_evals=0, converged=False
         )
+
+    # dcsrch's gtest: the sufficient-decrease slope ftol * phi'(0), used both
+    # in the Armijo threshold and in the boundary (stpmax/stpmin) tests.
+    gtest = ftol * dphi0
 
     is_bracketed = False
     stage = 1
@@ -219,8 +241,9 @@ def more_thuente_search(
 
         trial_f, trial_deriv = phi_dphi(step)
         num_evals += 1
+        last_evaluated_step = step
 
-        sufficient_decrease_threshold = phi0 + step * ftol * dphi0
+        sufficient_decrease_threshold = phi0 + step * gtest
 
         # Strong Wolfe convergence test
         if (
@@ -237,15 +260,20 @@ def more_thuente_search(
                 step=step, f_new=trial_f, dphi_new=trial_deriv,
                 num_evals=num_evals, converged=False,
             )
-        if step == step_max and trial_f <= sufficient_decrease_threshold and trial_deriv <= dphi0:
+        # dcsrch boundary tests ("WARNING: STP = STPMAX/STPMIN"). Fortran's
+        # warning outcomes still return the step taken, so a sufficiently
+        # decreasing, still-steep step pinned at stpmax (the 1-D minimizer
+        # lies beyond the bound-limited feasible segment) is accepted rather
+        # than re-proposed until maxiter is exhausted.
+        if step == step_max and trial_f <= sufficient_decrease_threshold and trial_deriv <= gtest:
             return LineSearchResult(
                 step=step, f_new=trial_f, dphi_new=trial_deriv,
-                num_evals=num_evals, converged=False,
+                num_evals=num_evals, converged=True,
             )
-        if step == step_min and (trial_f > sufficient_decrease_threshold or trial_deriv >= dphi0):
+        if step == step_min and (trial_f > sufficient_decrease_threshold or trial_deriv >= gtest):
             return LineSearchResult(
                 step=step, f_new=trial_f, dphi_new=trial_deriv,
-                num_evals=num_evals, converged=False,
+                num_evals=num_evals, converged=True,
             )
 
         # Stage transition: switch from modified function to direct minimization
@@ -299,8 +327,11 @@ def more_thuente_search(
             previous_interval_width = interval_width
             interval_width = abs(other_step - best_step)
 
+    # maxiter exhausted: report the last *evaluated* step (``step`` now holds
+    # the next, never-evaluated proposal) so that ``step``/``f_new`` describe
+    # the same point.
     return LineSearchResult(
-        step=step, f_new=trial_f, dphi_new=trial_deriv,
+        step=last_evaluated_step, f_new=trial_f, dphi_new=trial_deriv,
         num_evals=num_evals, converged=False,
     )
 
@@ -440,6 +471,7 @@ def armijo_search(
     ftol: float = 1e-3,
     maxiter: int = 20,
     contraction_factor: float = 0.5,
+    phi: Callable[[float], float] | None = None,
 ) -> LineSearchResult:
     """Armijo backtracking line search.
 
@@ -447,13 +479,31 @@ def armijo_search(
         f(x + alpha*d) <= f(x) + ftol * alpha * f'(x).d
 
     Each rejected trial is contracted by the given factor.
+
+    The condition only involves ``phi(alpha)``, so when a value-only
+    evaluator ``phi`` is supplied each trial costs a single function
+    evaluation and the result's ``dphi_new`` is NaN (never computed).
+    Without ``phi``, trials fall back to ``phi_dphi``.
     """
+    if maxiter < 1:
+        raise ValueError("maxiter must be at least 1.")
+
+    if dphi0 >= 0:
+        return LineSearchResult(
+            step=0.0, f_new=phi0, dphi_new=dphi0, num_evals=0, converged=False
+        )
+
     step = min(step, step_max)
     num_evals = 0
 
     for _ in range(maxiter):
-        trial_f, trial_deriv = phi_dphi(step)
+        if phi is not None:
+            trial_f = phi(step)
+            trial_deriv = float("nan")
+        else:
+            trial_f, trial_deriv = phi_dphi(step)
         num_evals += 1
+        last_evaluated_step = step
 
         if trial_f <= phi0 + ftol * step * dphi0:
             return LineSearchResult(
@@ -465,11 +515,41 @@ def armijo_search(
 
         if step < 1e-20:
             return LineSearchResult(
-                step=step, f_new=trial_f, dphi_new=trial_deriv,
+                step=last_evaluated_step, f_new=trial_f, dphi_new=trial_deriv,
                 num_evals=num_evals, converged=False,
             )
 
+    # Failure returns report the last *evaluated* step so that
+    # ``step``/``f_new`` describe the same point.
     return LineSearchResult(
-        step=step, f_new=trial_f, dphi_new=trial_deriv,
+        step=last_evaluated_step, f_new=trial_f, dphi_new=trial_deriv,
         num_evals=num_evals, converged=False,
     )
+
+
+class GradientLineSearchType(Enum):
+    """
+    Discoverability enum listing all built-in gradient-based line searches.
+
+    Call ``.build()`` to obtain a ready-to-use :class:`GradientLineSearch`
+    instance without importing concrete classes.
+    """
+
+    MORE_THUENTE = "more_thuente"
+    ARMIJO = "armijo"
+
+    def build(self) -> GradientLineSearch:
+        """
+        Construct the matching :class:`GradientLineSearch`.
+
+        Returns
+        -------
+        GradientLineSearch
+            Concrete line search for this enum member.
+        """
+        if self is GradientLineSearchType.MORE_THUENTE:
+            return MoreThuenteLineSearch()
+        elif self is GradientLineSearchType.ARMIJO:
+            return ArmijoBacktracking()
+        # Exhaustive match — new members must extend this method.
+        raise NotImplementedError(f"No build() implementation for {self!r}")

--- a/declivity/utils/population_initializers.py
+++ b/declivity/utils/population_initializers.py
@@ -415,3 +415,8 @@ class PopulationInitializerType(Enum):
                 return SimplexPopulationInitializer()
             case PopulationInitializerType.IDENTITY:
                 return IdentityPopulationInitializer()
+            case _:
+                # Exhaustive match — new members must extend this method.
+                raise NotImplementedError(
+                    f"No build() implementation for {self!r}"
+                )

--- a/experiments/handoff/covariance_transformations.py
+++ b/experiments/handoff/covariance_transformations.py
@@ -126,7 +126,6 @@ def run_handoff_study(
         cmaes_config = CMAESConfig(
             dimensions=dimensions, sigma=10.0,
         )
-        cmaes_config.diag_sigma = True
         cmaes_config.diag_eigen = True
 
         optimizer_cmaes = AlgorithmFactory.create_optimizer(


### PR DESCRIPTION
A full audit of every optimizer implementation (DES, CMA-ES, MF-CMA-ES, L-BFGS-B, Powell, Nelder-Mead) and the shared component layer, checking correct use of the swappable-component seams and hunting for porting bugs. The seams themselves were in good shape everywhere; this PR fixes the genuine defects the audit found, in five thematic commits.

## The two real porting bugs

**DES: history ring buffer phase-shifted one slot** from the `d_mean`/`pc` buffers. Iteration 1 sampled the never-written all-zero column 0, history entries paired with the wrong iteration's difference vectors for the whole first cycle, and the evolution-path reset fired at iterations H, 2H, … instead of 1, H+1, … as in DES.R. `histHead` now starts one slot before the first write, matching the reference exactly.

**MF-CMA-ES: warm-up decay factors misaligned** until the archive fills — the decay table was truncated to `min(g, window)` *before* the circular shift, underweighting history ~40x at generation 2 (d=10) and diverging from the R reference for the first ~window generations. Now the full window-length table is shifted first, with the zero-filled archive columns absorbing the meaningless entries, and the random-draw shapes match the reference's consumption. Distributional parity vs the oracle verified on 15 shared seeds (MWU/KS un-rejected).

Both bugs distort the sampling distribution during exactly the phase that decides which basin a run finds, and both were invisible to the statistical R cross-validation.

## Bookkeeping and accounting

- CMA-ES: the per-generation mean evaluation (charged to the budget) now feeds best tracking; auto-sigma no longer mutates the caller's config; a `generation == 0` restored state honors the restored sigma/covariance; sigma is always logged (`diag_sigma` removed — it blanked the default Step Size panel out of the box).
- DES: the initial population enters best tracking (a budget < λ no longer returns `inf`); the cumulative-mean evaluation respects an exhausted evaluation cap; `config.mu`/`config.weights` overrides are honored; `worst_fitness` guard precedence fixed.
- MF-CMA-ES: tolfun tests the sorted generation best (was unsorted member 0); `worst_fitness` no longer logs `inf` forever; generation 1 is logged and tolfun-tested; `use_ppmf=False` no longer burns a midpoint evaluation the reference doesn't make.
- Worst-fitness logging standardized to per-generation across all three evolutionary algorithms.
- L-BFGS-B: failed line searches keep an improving trial for reporting; failure returns report the last *evaluated* step so step/f_new describe the same point.
- Powell: budget check placed exactly where SciPy tests maxfun/maxiter; out-of-bounds x0 clipped with a warning, as SciPy does.

## Bound-constrained correctness (L-BFGS-B)

- More-Thuente's stpmax/stpmin boundary tests now use Fortran dcsrch's `gtest = ftol·φ'(0)` and take the step on the warning outcomes — previously a bound-limited search re-proposed the same point until maxiter and killed the run while holding a strictly better feasible point.
- Finite differencing is bounds-aware (one-sided on the feasible side when a probe would exit the box — iterates routinely sit exactly on bounds).
- The maximum feasible step is exact, making the post-line-search clip a true no-op, which lets FD mode reuse the line search's f_new instead of re-evaluating.
- The auto FD step is strategy-appropriate: `eps^(1/3)` for central differences, `sqrt(eps)` for forward.

## Component layer

- CLAMP repair sanitizes non-finite values *before* clipping (a NaN input previously repaired to 1.8e308, outside the box); `-inf` now lands on the lower bound.
- BOUNCE_BACK no longer infinitely recurses on zero-width bounds.
- `weighted_covariance` spends the centering DOF when the mean is computed internally.
- `initial_geometry=` + `config.initial_hessian` now raises on L-BFGS-B (the documented mutual exclusion; previously the geometry silently won, unlike Powell).
- Armijo evaluates only φ per trial (1 eval instead of 3 in FD mode), rejects non-descent directions; both gradient line searches validate maxiter.
- New `*Type` discoverability enums for the gradient-strategy and both line-search families; `PopulationInitializerType.build` gained its raising fall-through.
- Dead surface removed: DES `ft`/`ft_scale`/`diag_ft`, MF-CMA-ES `tolx`/`tolxup`, the wrong-for-dense-B0 dead loop in subspace minimization, the unused global-RNG `sample_from_history` helper.

## Validation

- `powell_vs_scipy` and `neldermead_vs_scipy`: **exact-0** across the full grid (bit-identical to scipy preserved).
- `geometry_seed_identity`: PASS.
- `cmaes_vs_reference`: machine-precision equivalence on convex problems, same-basin on multimodal (unchanged guarantees); CMAESState resume populations remain bit-identical.
- MF-CMA-ES distributional parity vs the R-port oracle on 15 shared seeds.
- All six algorithms smoke-tested to convergence; DES budget cap verified exact (5-eval budget → exactly 5 evals, finite best).

Known deliberate non-changes: the budget-enforcement asymmetry between population algorithms (hard cap via generation trimming) and single-point/per-point loops (top-of-loop check, small overshoot) is left as-is for CMA-ES/MF-CMA-ES — the "always complete the population" behavior is the documented fix for the historical mid-population break bug. DES trajectories intentionally change (the ring-buffer fix); `des_vs_r` is statistical and should be re-run before the next report regeneration.